### PR TITLE
Better navigation for preview documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,10 +57,26 @@ on the website and in the documentation contents.
 To do so, run the following command:
 
 ```bash
-bundle exec jekyll serve
+bundle exec jekyll serve --config '_config.yml'
 ```
 
 It will start the website on [http://localhost:4000](http://localhost:4000).
+
+## Preview and Previous site baselines
+
+The website may include preview and deprecated baselines, mainly to serve the documentation.
+The websites have slightly different layouts to help users navigate (links, headers, etc.).
+
+Alternative baselines are managed in the `main` branch,
+but the content comes from other Git branches.
+For example, if the `3.x` baseline is a preview one...
+
+- There is a branch in the repository, for example `3.0.0-beta` for `3.x`
+- There is a `wiremorg.org/3.x` entry on the website.
+  It is included from the branch via Git submodules and packaging scripts in GitHub Actions
+- For this version, there is a `_config-3.x.yml` file that defines configuration overrides for this version
+- To build and test the baseline on a local machine, one needs to include the overrides config file into `jekyll build` and `jekyll serve` commands.
+  For example, `bundle exec jekyll serve --config '_config.yml,_config-3.x.yml'`.
 
 ## Deploying the website
 

--- a/_config-3.x.yml
+++ b/_config-3.x.yml
@@ -1,4 +1,5 @@
 url: "https://wiremock.org/3.x"
 destination: "./tmp/site_3x"
-wiremock_beta_site: true
-wiremock_ga_site: false
+wiremock_preview_site: true
+wiremock_baseline: 3.x
+wiremock_preview: true

--- a/_config.yml
+++ b/_config.yml
@@ -223,8 +223,7 @@ compress_html:
 
 wiremock_version: 2.35.0
 wiremock_beta_version: 3.0.0-beta-8
-wiremock_beta_site: false
-wiremock_ga_site: true
+wiremock_baseline: 2.x
 
 community_slack:
   join_url: http://slack.wiremock.org/

--- a/_data/baselines.yml
+++ b/_data/baselines.yml
@@ -1,6 +1,9 @@
 # Current GA Version of WireMock
-current: 2.x
+current:
+  id: 2.x
 # List of preview versions
-preview: 3.x
+preview: 
+  id: 3.x
+  scopeUrl: https://github.com/orgs/wiremock/projects/5
 # List of old versions documentation for which is served on the website
 archive:

--- a/_data/baselines.yml
+++ b/_data/baselines.yml
@@ -1,0 +1,6 @@
+# Current GA Version of WireMock
+current: 2.x
+# List of preview versions
+preview: 3.x
+# List of old versions documentation for which is served on the website
+archive:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,12 +8,12 @@ main:
           subnavLink: "/docs/"
         - name: "WireMock 3.x for Java (Preview)"
           subnavLink: "/3.x/docs/"
-          wiremock_beta_link: true
+          wiremock_baseline: 3.x
         - name: "WireMock Standalone"
           subnavLink: "/docs/running-standalone/"
         - name: "WireMock 3.x Standalone (Preview)"
           subnavLink: "/3.x/docs/running-standalone/"
-          wiremock_beta_link: true
+          wiremock_baseline: 3.x
         - name: "WireMock in Docker"
           subnavLink: "/docs/docker/"
         - name: "WireMock Python"

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -101,13 +101,15 @@
                   {% if link.subnav %}
                   <div class="divSubNav">
                     {% for subnavigation in link.subnavLinks %}
-                      {% if link.subnav.wiremock_beta_link %}
-                        {% if site.wiremock_ga_site = true %}
-                          <a href="{{ subnavigation.subnavLink | absolute_url }}">
+                      {% if subnavigation.wiremock_baseline %}
+                        <!-- Show the preview link -->
+                        {% if site.wiremock_baseline != subnavigation.wiremock_baseline %}
+                        <a href="{{ subnavigation.subnavLink | absolute_url }}">
                           {{ subnavigation.name }}
                         </a>
                         {% endif %}
                       {% else %}
+                        <!-- General link -->
                         <a href="{{ subnavigation.subnavLink | absolute_url }}">
                           {{ subnavigation.name }}
                         </a>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -23,6 +23,30 @@ layout: default
       Need help? Join the <a href="{{site.community_slack.join_url}}">WireMock community Slack</a>
     </div>
 
+    {% if site.wiremock_baseline == site.data.baselines.current %} 
+    <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
+      This is the documentation for the WireMock {{ site.data.baselines.current }} baseline.
+      See the documentation for WireMock {{ site.data.baselines.preview }} preview 
+      <a href="{{  page.url | prepend: site.data.baselines.preview | prepend: '/'  | absolute_url }}">here</a>
+    </div>
+    {% else %}
+      {% if site.wiremock_baseline == site.data.baselines.current %} 
+      <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
+        <b>WARNING: </b>
+        This is the documentation for WireMock {{ site.data.baselines.previews }} preview.
+        See the documentation for the current WireMock {{ site.data.baselines.current }} baseline
+        <a href="{{  page.url | prepend: site.data.baselines.current | prepend: '/'  | absolute_url }}">here</a>
+      </div>
+      {% else %}
+      <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
+        <b>WARNING: </b>
+        This is the archive documentation for WireMock {{ site.wiremock_baseline }}.
+        See the documentation for the current WireMock {{ site.data.baselines.current }} baseline
+        <a href="{{  page.url | prepend: site.data.baselines.current | prepend: '/'  | absolute_url }}">here</a>
+      </div>
+      {% endif %}  
+    {% endif %}
+
     <div class="page__inner-wrap">
       <header>
         {% if page.title %}<h1 class="page__title" itemprop="headline">{{ page.title | markdownify | remove: "<p>" | remove: "</p>" }}</h1>{% endif %}

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -23,26 +23,29 @@ layout: default
       Need help? Join the <a href="{{site.community_slack.join_url}}">WireMock community Slack</a>
     </div>
 
-    {% if site.wiremock_baseline == site.data.baselines.current %} 
+    {% if site.wiremock_baseline == site.data.baselines.current.id %} 
     <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
-      This is the documentation for the WireMock {{ site.data.baselines.current }} baseline.
-      See the documentation for WireMock {{ site.data.baselines.preview }} preview 
-      <a href="{{  page.url | prepend: site.data.baselines.preview | prepend: '/'  | absolute_url }}">here</a>
+      This document is for the WireMock {{ site.data.baselines.current.id }} baseline.
+      See the documentation for WireMock {{ site.data.baselines.preview.id }} preview 
+      <a href="{{  page.url | prepend: site.data.baselines.preview.id | prepend: '/'  | absolute_url }}">here</a>
     </div>
     {% else %}
-      {% if site.wiremock_baseline == site.data.baselines.current %} 
+      {% if site.wiremock_baseline == site.data.baselines.preview.id %} 
       <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
         <b>WARNING: </b>
-        This is the documentation for WireMock {{ site.data.baselines.previews }} preview.
-        See the documentation for the current WireMock {{ site.data.baselines.current }} baseline
-        <a href="{{  page.url | prepend: site.data.baselines.current | prepend: '/'  | absolute_url }}">here</a>
+        This document is for WireMock {{ site.data.baselines.preview.id }} preview.
+        See the documentation for the current WireMock {{ site.data.baselines.current.id }} baseline
+        <a href="{{  page.url | prepend: site.data.baselines.current.id | prepend: '/'  | absolute_url }}">here</a>.
+        If you are interested to know more what is planned for WireMock {{ site.data.baselines.preview.id }}, 
+        see
+        <a href="{{  site.data.baselines.preview.scopeUrl | absolute_url }}">this page</a>.
       </div>
       {% else %}
       <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
         <b>WARNING: </b>
-        This is the archive documentation for WireMock {{ site.wiremock_baseline }}.
-        See the documentation for the current WireMock {{ site.data.baselines.current }} baseline
-        <a href="{{  page.url | prepend: site.data.baselines.current | prepend: '/'  | absolute_url }}">here</a>
+        This document is for an old WireMock {{ site.wiremock_baseline }} baseline.
+        See the documentation for the current WireMock {{ site.data.baselines.current.id }} baseline
+        <a href="{{  page.url | prepend: site.data.baselines.current.id | prepend: '/'  | absolute_url }}">here</a>
       </div>
       {% endif %}  
     {% endif %}


### PR DESCRIPTION
This makes it easier to navigate documentation by adding warning boxes to the current and preview versions. It helps others to discover documentation pages though documentation restructuring may lead to dead links later (story for later).

## Current version

![image](https://user-images.githubusercontent.com/3000480/235347252-856b5a5a-42aa-45f9-88ae-900e7b6922ed.png)


## Preview version

![image](https://user-images.githubusercontent.com/3000480/235347162-57b78c8d-d57d-4f5a-9314-bae6040aaff7.png)

