### PR TITLE
Existing Documentation Restructuring

### DIFF
--- a/_data/doc-categories.yml
+++ b/_data/doc-categories.yml
@@ -1,28 +1,26 @@
 setup:
-  title: Setup
+  title: Getting started
   pages:
     - getting-started
     - download-and-installation
-    - running-standalone
-    - docker
-    - android
-    - spring-boot
 
-configuration:
-  title: Configuration
+standalone:
+  title: WireMock Standalone
   pages:
-    - https
-    - multi-domain-mocking
+    - docker
+    - running-standalone
 
 java:
   title: Java Usage
   pages:
     - junit-jupiter
     - junit-extensions
+    - spring-boot
     - java-usage
     - configuration
     - running-without-http-server
-
+    - android
+    
 stubbing-and-verifying:
   title: Stubbing & Verifying
   pages:
@@ -38,6 +36,12 @@ record-playback:
   title: Record & Playback
   pages:
     - record-playback
+
+configuration:
+  title: Advanced use-cases
+  pages:
+    - https
+    - multi-domain-mocking
 
 extensibility:
   title: Extensibility

--- a/_data/doc-categories.yml
+++ b/_data/doc-categories.yml
@@ -2,6 +2,7 @@ setup:
   title: Getting started
   pages:
     - getting-started
+    - quickstart/java-junit
     - download-and-installation
 
 standalone:

--- a/_data/doc-categories.yml
+++ b/_data/doc-categories.yml
@@ -42,6 +42,7 @@ configuration:
   pages:
     - https
     - multi-domain-mocking
+    - advanced/deploy-to-servlet-container
 
 extensibility:
   title: Extensibility

--- a/_data/doc-categories.yml
+++ b/_data/doc-categories.yml
@@ -9,7 +9,8 @@ standalone:
   title: WireMock Standalone
   pages:
     - docker
-    - running-standalone
+    - standalone/java-jar
+    - standalone/administration
 
 java:
   title: Java Usage
@@ -55,4 +56,4 @@ extensibility:
 reference:
   title: Reference
   pages:
-    - api
+    - standalone/admin-api-reference

--- a/_data/doc-categories.yml
+++ b/_data/doc-categories.yml
@@ -46,6 +46,7 @@ configuration:
     - https
     - multi-domain-mocking
     - advanced/deploy-to-servlet-container
+    - advanced/java7
 
 extensibility:
   title: Extensibility

--- a/_data/doc-categories.yml
+++ b/_data/doc-categories.yml
@@ -1,9 +1,10 @@
 setup:
   title: Getting started
   pages:
-    - getting-started
+    - overview
     - quickstart/java-junit
     - download-and-installation
+    - getting-started
 
 standalone:
   title: WireMock Standalone

--- a/_docs/advanced/deploy-to-servlet-container.md
+++ b/_docs/advanced/deploy-to-servlet-container.md
@@ -1,0 +1,28 @@
+---
+layout: docs
+title: Deploying into a servlet container
+meta_title: Deploying into a servlet container | WireMock
+description: "WireMock can be packaged up as a WAR and deployed into a servlet
+container. Here is how"
+---
+
+WireMock can be packaged up as a WAR and deployed into a servlet
+container, with some caveats: fault injection and browser proxying won't
+work, \_\_files won't be treated as a docroot as with standalone, the
+server cannot be remotely shutdown, and the container must be configured
+to explode the WAR on deployment. This has only really been tested in
+Tomcat 6 and Jetty, so YMMV. Running standalone is definitely the
+preferred option.
+
+The easiest way to create a WireMock WAR project is to clone the [sample
+app](https://github.com/tomakehurst/wiremock/tree/master/sample-war)
+
+### Deploying under a sub-path of the context root
+
+If you want WireMock's servlet to have a non-root path, the additional
+init param `mappedUnder` must be set with the sub-path web.xml (in
+addition to configuring the servlet mapping appropriately).
+
+See [the custom mapped WAR
+example](https://github.com/wiremock/wiremock/blob/master/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml)
+for details.

--- a/_docs/advanced/java7.md
+++ b/_docs/advanced/java7.md
@@ -1,0 +1,53 @@
+---
+layout: docs
+title: WireMock on Java 1.7
+meta_title: "Using old WireMock versions with Java 1.7"
+description: Recent WireMock versions do not support Java 1.7, but you can run older versions to achieve that
+---
+
+> **WARNING:** Recent WireMock versions do not support Java 1.7, but you can run older versions to achieve that.
+> The Java 7 version was deprecated in the 2.x line and version 2.27.2 is the last release available.
+> There will be no bugfixes and security patches provided.
+> Make sure to update as soon as possible to Java 11 or above.
+
+The Java 7 distribution is aimed primarily at Android developers and enterprise Java teams still using Java Runtime Environment (JRE) 1.7.
+Some of its dependencies are not set to the latest versions e.g. Jetty 9.2.x is used,
+as this is the last minor version to retain Java 7 compatibility.
+
+## Maven dependencies
+
+JUnit:
+
+```xml
+<dependency>
+    <groupId>com.github.tomakehurst</groupId>
+    <artifactId>wiremock</artifactId>
+    <version>2.27.2</version>
+    <scope>test</scope>
+</dependency>
+```
+
+Standalone JAR:
+
+```xml
+<dependency>
+    <groupId>com.github.tomakehurst</groupId>
+    <artifactId>wiremock-standalone</artifactId>
+    <version>2.27.2</version>
+    <scope>test</scope>
+</dependency>
+```
+
+## Gradle dependencies
+
+JUnit:
+
+```groovy
+testImplementation "com.github.tomakehurst:wiremock:2.27.2"
+```
+
+Standalone JAR:
+
+```groovy
+testImplementation "com.github.tomakehurst:wiremock-standalone:2.27.2"
+```

--- a/_docs/download-and-installation.md
+++ b/_docs/download-and-installation.md
@@ -6,24 +6,11 @@ toc_rank: 13
 description: WireMock is distributed in two flavours - a standard JAR containing just WireMock, and a standalone fat JAR containing WireMock plus all its dependencies.
 ---
 
-WireMock is distributed in two flavours - a standard JAR containing just WireMock, and a standalone fat JAR containing
+WireMock is distributed in two flavours - a standard JAR containing just WireMock, and a standalone uber JAR containing
 WireMock plus all its dependencies.
 
 Most of the standalone JAR's dependencies are shaded i.e. they are hidden in alternative packages. This allows WireMock to be used in projects with
 conflicting versions of its dependencies. The standalone JAR is also runnable (see [Running as a Standalone Process](../running-standalone/)).
-
-Additionally, versions of these JARs are distributed for both Java 7 and Java 8+.
-
-The Java 7 distribution is aimed primarily at Android developers and enterprise Java teams still using JRE7. Some of its
-dependencies are not set to the latest versions e.g. Jetty 9.2.x is used, as this is the last minor version to retain Java 7 compatibility.
-
-The Java 8+ build endeavours to track the latest version of all its major dependencies.
-
-> **note**
->
-> The Java 7 version is now deprecated in the 2.x line and version 2.27.2 is the last release available. It's strongly
-> recommended that you use the Java 8 releases if possible.
-
 
 ## 3.x beta
 
@@ -97,43 +84,6 @@ Gradle (standalone):
 
 ```groovy
 testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wiremock_version }}"
-```
-
-
-## Java 7 (deprecated)
-
-Maven:
-
-```xml
-<dependency>
-    <groupId>com.github.tomakehurst</groupId>
-    <artifactId>wiremock</artifactId>
-    <version>2.27.2</version>
-    <scope>test</scope>
-</dependency>
-```
-
-Maven (standalone):
-
-```xml
-<dependency>
-    <groupId>com.github.tomakehurst</groupId>
-    <artifactId>wiremock-standalone</artifactId>
-    <version>2.27.2</version>
-    <scope>test</scope>
-</dependency>
-```
-
-Gradle:
-
-```groovy
-testImplementation "com.github.tomakehurst:wiremock:2.27.2"
-```
-
-Gradle (standalone):
-
-```groovy
-testImplementation "com.github.tomakehurst:wiremock-standalone:2.27.2"
 ```
 
 ## Direct download

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -19,9 +19,3 @@ You can <a id="wiremock-standalone-download" href="https://repo1.maven.org/maven
 here</a>.
 
 See [Running as a Standalone Process](../running-standalone/) running-standalone for more details and commandline options.
-
-## Fetching all of your stub mappings (and checking WireMock is working)
-
-A GET request to the root admin URL e.g `http://localhost:8080/__admin`
-will return all currently registered stub mappings. This is a useful way
-to check whether WireMock is running on the host and port you expect:

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -1,21 +1,36 @@
 ---
 layout: docs
-title: WireMock Quick Start
-meta_title: WireMock Quick Start Guide
+title: WireMock Tutorials
+meta_title: Listing of WireMock Quick Starts and Tutorials
 toc_rank: 10
-redirect_from: "/getting-started.html"
-description: WireMock is distributed via Maven Central and can be included in your project using common build tools’ dependency management. Get started with WireMock.
+redirect_from:
+    - "/getting-started.html"
+    - "/docs/tutorials.html"
+description: Provides links to WireMock tutorials and other entry materials
 ---
 
+Getting Started with WireMock in your project?
+Check out the guidelines below.
 
-## Running standalone
+## Quick Starts
 
-The WireMock server can be run in its own process, and configured via
-the Java API, JSON over HTTP or JSON files.
+At the moment, we provide the following quick starts for beginners:
 
-This will start the server on port 8080:
+- [API Mocking with Java and JUnit 4](../quickstart/java-junit)
+- [Downloading and Installing WireMock](../download-and-installation)
 
-You can <a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/{{ site.wiremock_version }}/wiremock-jre8-standalone-{{ site.wiremock_version }}.jar">download the standalone JAR from
-here</a>.
+<!-- TODO: Add standalone in Docker -->
 
-See [Running as a Standalone Process](../running-standalone/) running-standalone for more details and commandline options.
+## Featured tutorials
+
+Here are some good tutorials from the [External Resources](/external-resources) you can use:
+
+- [WireMock Basics Workshop](https://github.com/basdijkstra/wiremock-workshop), by Bas Dijkstra
+- [Running your acceptance tests in Kubernetes using WireMock](https://blog.sebastian-daschner.com/entries/acceptance_tests_wiremock_kubernetes), by Sebastian Daschner
+- [Running WireMock on Android](https://handstandsam.com/2016/01/30/running-wiremock-on-android/), by Sam Edwards
+
+## Contributing tutorials
+
+If you know about additional tutorials and extensions for WireMock,
+[let us know](https://github.com/wiremock/wiremock.org/issues/new?assignees=&labels=documentation&template=3_documentation+copy.yml&title=Add%20Tutorial%20to%20listing)!
+If you would like to write a new tutorial, see the [Contributor Guide](https://github.com/wiremock/community/tree/main/contributing#tutorials-and-guides).

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -8,44 +8,6 @@ description: WireMock is distributed via Maven Central and can be included in yo
 ---
 
 
-
-## Writing a test with JUnit 5.x
-
-See [JUnit 5+ Jupiter Usage](../junit-jupiter/) for various JUnit 5 usage scenarios.
-
-## Non-JUnit and general Java usage
-
-If you're not using JUnit or neither of the WireMock rules manage its
-lifecycle in a suitable way you can construct and start the server
-directly:
-
-```java
-WireMockServer wireMockServer = new WireMockServer(wireMockConfig().port(8089)); //No-args constructor will start on port 8080, no HTTPS
-wireMockServer.start();
-
-// Do some stuff
-
-WireMock.reset();
-
-// Finish doing stuff
-
-wireMockServer.stop();
-```
-
-If you've changed the port number and/or you're running the server on
-another host, you'll need to tell the client:
-
-```java
-WireMock.configureFor("wiremock.host", 8089);
-```
-
-And if you've deployed it into a servlet container under a path other
-than root you'll need to set that too:
-
-```java
-WireMock.configureFor("tomcat.host", 8080, "/wiremock");
-```
-
 ## Running standalone
 
 The WireMock server can be run in its own process, and configured via

--- a/_docs/getting-started.md
+++ b/_docs/getting-started.md
@@ -1,114 +1,13 @@
 ---
 layout: docs
-title: Getting Started
+title: WireMock Quick Start
 meta_title: WireMock Quick Start Guide
 toc_rank: 10
 redirect_from: "/getting-started.html"
 description: WireMock is distributed via Maven Central and can be included in your project using common build tools’ dependency management. Get started with WireMock.
 ---
 
-## Installation
 
-WireMock is distributed via Maven Central and can be included in your project using common build tools' dependency management.
-
-To add the standard WireMock JAR as a project dependency, put the following in the dependencies section of your build file:
-
-### Maven
-
-```xml
-<dependency>
-    <groupId>com.github.tomakehurst</groupId>
-    <artifactId>wiremock-jre8</artifactId>
-    <version>{{ site.wiremock_version }}</version>
-    <scope>test</scope>
-</dependency>
-```
-
-### Gradle
-
-```groovy
-testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
-```
-
-WireMock is also shipped in Java 7 and standalone versions, both of which work better in certain contexts.
-See [Download and Installation](../download-and-installation/) for details.
-
-## Writing a test with JUnit 4.x
-
-To use WireMock's fluent API add the following import:
-
-```java
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-```
-
-WireMock ships with some JUnit rules to manage the server's lifecycle
-and setup/tear-down tasks. To start and stop WireMock per-test case, add
-the following to your test class (or a superclass of it):
-
-```java
-@Rule
-public WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructor defaults to port 8080
-```
-
-Now you're ready to write a test case like this:
-
-```java
-@Test
-public void exampleTest() {
-    stubFor(post("/my/resource")
-        .withHeader("Content-Type", containing("xml"))
-        .willReturn(ok()
-            .withHeader("Content-Type", "text/xml")
-            .withBody("<response>SUCCESS</response>")));
-
-    Result result = myHttpServiceCallingObject.doSomething();
-    assertTrue(result.wasSuccessful());
-
-    verify(postRequestedFor(urlPathEqualTo("/my/resource"))
-        .withRequestBody(matching(".*message-1234.*"))
-        .withHeader("Content-Type", equalTo("text/xml")));
-}
-```
-
-For many more examples of JUnit tests look no further than [WireMock's
-own acceptance
-tests](https://github.com/tomakehurst/wiremock/tree/master/src/test/java/com/github/tomakehurst/wiremock)
-
-For more details on verifying requests and stubbing responses, see [Stubbing](../stubbing) and [Verifying](../verifying/)
-
-For more information on the JUnit rule see [The JUnit Rule](../junit-rule/).
-
-## Changing port numbers
-
-For a bit more control over the settings of the WireMock server created
-by the rule you can pass a fluently built Options object to either
-(non-deprecated) rule's constructor:
-
-```java
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-...
-
-@Rule
-public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
-```
-
-### Random port numbers
-
-You can have WireMock (or more accurately the JVM) pick random, free
-HTTP and HTTPS ports (which is a great idea if you want to run your
-tests concurrently):
-
-```java
-@Rule
-public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
-```
-
-Then find out which ports to use from your tests as follows:
-
-```java
-int port = wireMockRule.port();
-int httpsPort = wireMockRule.httpsPort();
-```
 
 ## Writing a test with JUnit 5.x
 
@@ -164,26 +63,3 @@ See [Running as a Standalone Process](../running-standalone/) running-standalone
 A GET request to the root admin URL e.g `http://localhost:8080/__admin`
 will return all currently registered stub mappings. This is a useful way
 to check whether WireMock is running on the host and port you expect:
-
-## Deploying into a servlet container
-
-WireMock can be packaged up as a WAR and deployed into a servlet
-container, with some caveats: fault injection and browser proxying won't
-work, \_\_files won't be treated as a docroot as with standalone, the
-server cannot be remotely shutdown, and the container must be configured
-to explode the WAR on deployment. This has only really been tested in
-Tomcat 6 and Jetty, so YMMV. Running standalone is definitely the
-preferred option.
-
-The easiest way to create a WireMock WAR project is to clone the [sample
-app](https://github.com/tomakehurst/wiremock/tree/master/sample-war)
-
-### Deploying under a sub-path of the context root
-
-If you want WireMock's servlet to have a non-root path, the additional
-init param `mappedUnder` must be set with the sub-path web.xml (in
-addition to configuring the servlet mapping appropriately).
-
-See [the custom mapped WAR
-example](https://github.com/tomakehurst/wiremock/blob/master/sample-war/src/main/webappCustomMapping/WEB-INF/web.xml)
-for details.

--- a/_docs/https.md
+++ b/_docs/https.md
@@ -1,12 +1,12 @@
 ---
 layout: docs
-title: HTTPS
-meta_title: Using WireMock with HTTPS using self-signed or custom certificates | WireMock
+title: Serving HTTPs
+meta_title: Using WireMock with HTTPs using self-signed or custom certificates | WireMock
 redirect_from: "/https.html"
 description: WireMock can optionally accept requests over HTTPS. By default it will serve its own self-signed TLS certificate.
 ---
 
-WireMock can optionally accept requests over HTTPS. By default it will serve its own self-signed TLS certificate, but this can be
+WireMock can optionally accept requests over HTTPs. By default it will serve its own self-signed TLS certificate, but this can be
 overridden if required by providing a keystore containing another certificate.
 
 ## Handling HTTPS requests

--- a/_docs/java-usage.md
+++ b/_docs/java-usage.md
@@ -6,6 +6,10 @@ redirect_from: "/java-usage.html"
 description: If you want to use WireMock from Java (or any other JVM language) outside of JUnit you can programmatically create, start and stop the server.
 ---
 
+If you're not using JUnit or neither of the WireMock rules manage its
+lifecycle in a suitable way you can construct and start the server
+directly.
+
 ## The Server
 
 If you want to use WireMock from Java (or any other JVM language)
@@ -26,6 +30,22 @@ For more details of the `options()` builder accepted by the constructor see [Con
 As with stubbing and verification via the [JUnit rule](../junit-rule/) you can call the
 stubbing/verifying DSL from the server object as an alternative to
 calling the client.
+
+### Managing ports
+
+If you've changed the port number and/or you're running the server on
+another host, you'll need to tell the client:
+
+```java
+WireMock.configureFor("wiremock.host", 8089);
+```
+
+And if you've deployed it into a servlet container under a path other
+than root you'll need to set that too:
+
+```java
+WireMock.configureFor("tomcat.host", 8080, "/wiremock");
+```
 
 ## The Client
 

--- a/_docs/junit-extensions.md
+++ b/_docs/junit-extensions.md
@@ -7,6 +7,7 @@ redirect_from:
   - "/docs/junit-rule/index.html"
   - "/docs/junit-rule/"
   - "/junit-rule/"
+  - "/docs/junit-4"
 description: WireMock includes a JUnit rule, compatible with JUnit 4.x and JUnit 5 Vintage. This provides a convenient way to manage one or more WireMock instances in your test cases.
 ---
 

--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -3,6 +3,8 @@ layout: docs
 title: "JUnit 5+ Jupiter"
 meta_title: Using WireMock's JUnit Jupiter extension | WireMock
 description: WireMock includes a JUnit Jupiter extension which is used to manage the lifecycle and configuration of one or more WireMock instances in your test case.
+redirect_from:
+  - "/docs/junit-5"
 ---
 
 The JUnit Jupiter extension simplifies running of one or more WireMock instances in a Jupiter test class.

--- a/_docs/overview.md
+++ b/_docs/overview.md
@@ -1,0 +1,51 @@
+---
+layout: docs
+title: Overview
+meta_title: WireMock Overview and Basics
+toc_rank: 1
+description: Top-level overview of WireMock
+---
+
+**WireMock** is a popular open-source tool for API mock testing
+with over 5 million downloads per month.
+It can help you to create stable test and development environments,
+isolate yourself from flakey 3rd parties
+and simulate APIs that don't exist yet.
+
+Started in 2011 as a Java library by [Tom Akehurst](https://github.com/tomakehurst),
+now WireMock spans across multiple programming languages and technology stacks.
+It can run as a library or client wrapper in many languages, or as a standalone server.
+There is a big community behind the project and its ecosystem.
+
+WireMock supports several approaches for creating mock APIs -
+in code, via its REST API, as JSON files and by recording HTTP traffic proxied to another destination.
+WireMock has a rich matching system, allowing any part of an incoming request to be matched against complex and precise criteria.
+Responses of any complexity can be dynamically generated via the Handlebars based templating system.
+Finally, WireMock is easy to integrate into any workflow due to its numerous extension points and comprehensive APIs.
+
+## Key features
+
+- HTTP response stubbing, matchable on URL, header and body content patterns
+- Request verification
+- Runs in unit tests, as a standalone process or as a WAR app
+- Record/playback of stubs
+- Configurable response delays and Fault injection
+- Per-request conditional proxying
+- Browser proxying for request inspection and replacement
+- Stateful behaviour simulation
+
+All the features are configurable via a fluent Java API and JSON files,
+or via JSON over HTTP for the standalone service.
+
+## Getting Started
+
+Check out WireMock Quick-starts and tutorials [here](../getting-started).
+
+## WireMock Ecosystem
+
+WireMock has implementations and adapters for other languages and test frameworks.
+It supports adapters and implementations for various technology stacks, including Python, .NET, Golang, and Rust.
+For the JVM ecosystem, there are libraries for Spring Boot, Quarkus, Kotlin, Testcontainers and other.
+WireMock can also run on Android support, and soon to provide official gRPC and GraphQL adapters.
+
+You can learn more about [WireMock Ecosystem here](https://github.com/wiremock/ecosystem).

--- a/_docs/quickstart/java-junit.md
+++ b/_docs/quickstart/java-junit.md
@@ -1,0 +1,110 @@
+---
+layout: docs
+title: "Quick Start: API Mocking with Java and JUnit 4"
+meta_title: "API Mocking QuickStart with Java and JUnit 4 | WireMock" 
+description: "Shows how to write your API Client first test with WireMock and JUnit"
+---
+
+## Installation
+
+WireMock is distributed via Maven Central and can be included in your project using common build tools' dependency management.
+
+To add the standard WireMock JAR as a project dependency, put the following in the dependencies section of your build file:
+
+### Maven
+
+```xml
+<dependency>
+    <groupId>com.github.tomakehurst</groupId>
+    <artifactId>wiremock-jre8</artifactId>
+    <version>{{ site.wiremock_version }}</version>
+    <scope>test</scope>
+</dependency>
+```
+
+### Gradle
+
+```groovy
+testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
+```
+
+WireMock is also shipped in Java 7 and standalone versions, both of which work better in certain contexts.
+See [Download and Installation](../download-and-installation/) for details.
+
+
+## Writing a test with JUnit 4.x
+
+To use WireMock's fluent API add the following import:
+
+```java
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+```
+
+WireMock ships with some JUnit rules to manage the server's lifecycle
+and setup/tear-down tasks. To start and stop WireMock per-test case, add
+the following to your test class (or a superclass of it):
+
+```java
+@Rule
+public WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructor defaults to port 8080
+```
+
+Now you're ready to write a test case like this:
+
+```java
+@Test
+public void exampleTest() {
+    stubFor(post("/my/resource")
+        .withHeader("Content-Type", containing("xml"))
+        .willReturn(ok()
+            .withHeader("Content-Type", "text/xml")
+            .withBody("<response>SUCCESS</response>")));
+
+    Result result = myHttpServiceCallingObject.doSomething();
+    assertTrue(result.wasSuccessful());
+
+    verify(postRequestedFor(urlPathEqualTo("/my/resource"))
+        .withRequestBody(matching(".*message-1234.*"))
+        .withHeader("Content-Type", equalTo("text/xml")));
+}
+```
+
+For many more examples of JUnit tests look no further than [WireMock's
+own acceptance
+tests](https://github.com/tomakehurst/wiremock/tree/master/src/test/java/com/github/tomakehurst/wiremock)
+
+For more details on verifying requests and stubbing responses, see [Stubbing](../stubbing) and [Verifying](../verifying/)
+
+For more information on the JUnit rule see [The JUnit Rule](../junit-rule/).
+
+## Changing port numbers
+
+For a bit more control over the settings of the WireMock server created
+by the rule you can pass a fluently built Options object to either
+(non-deprecated) rule's constructor:
+
+```java
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+...
+
+@Rule
+public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
+```
+
+### Random port numbers
+
+You can have WireMock (or more accurately the JVM) pick random, free
+HTTP and HTTPS ports (which is a great idea if you want to run your
+tests concurrently):
+
+```java
+@Rule
+public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+```
+
+Then find out which ports to use from your tests as follows:
+
+```java
+int port = wireMockRule.port();
+int httpsPort = wireMockRule.httpsPort();
+```

--- a/_docs/quickstart/java-junit.md
+++ b/_docs/quickstart/java-junit.md
@@ -5,10 +5,20 @@ meta_title: "API Mocking QuickStart with Java and JUnit 4 | WireMock"
 description: "Shows how to write your API Client first test with WireMock and JUnit"
 ---
 
-## Installation
+In this guide we will write an API Unit test with WireMock and JUnit 4.
+
+## Prerequisites
+
+- Java 11, 17 or JDK 1.8
+- Maven or Gradle, recent versions
+- A Java project, based on Maven and Gradle
+- A Unit test file which we will use as a playground
+
+<!-- TODO: Would be nice to introduce an archetype or a clone-able demo repo -->
+
+## Add WireMock Dependency to your project
 
 WireMock is distributed via Maven Central and can be included in your project using common build tools' dependency management.
-
 To add the standard WireMock JAR as a project dependency, put the following in the dependencies section of your build file:
 
 ### Maven
@@ -28,11 +38,10 @@ To add the standard WireMock JAR as a project dependency, put the following in t
 testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
 ```
 
-WireMock is also shipped in Java 7 and standalone versions, both of which work better in certain contexts.
-See [Download and Installation](../download-and-installation/) for details.
+## Add the WireMock rule
 
-
-## Writing a test with JUnit 4.x
+WireMock ships with some JUnit rules to manage the server's lifecycle
+and setup/tear-down tasks.
 
 To use WireMock's fluent API add the following import:
 
@@ -40,8 +49,7 @@ To use WireMock's fluent API add the following import:
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 ```
 
-WireMock ships with some JUnit rules to manage the server's lifecycle
-and setup/tear-down tasks. To start and stop WireMock per-test case, add
+To automatically start and stop WireMock per-test case, add
 the following to your test class (or a superclass of it):
 
 ```java
@@ -49,39 +57,38 @@ the following to your test class (or a superclass of it):
 public WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructor defaults to port 8080
 ```
 
+## Write a test
+
 Now you're ready to write a test case like this:
 
 ```java
 @Test
 public void exampleTest() {
+    // Setup the WireMock mapping stub for the test
     stubFor(post("/my/resource")
         .withHeader("Content-Type", containing("xml"))
         .willReturn(ok()
             .withHeader("Content-Type", "text/xml")
             .withBody("<response>SUCCESS</response>")));
 
+    // Send the request and receive the response
     Result result = myHttpServiceCallingObject.doSomething();
     assertTrue(result.wasSuccessful());
 
+    // Verify the response
     verify(postRequestedFor(urlPathEqualTo("/my/resource"))
         .withRequestBody(matching(".*message-1234.*"))
         .withHeader("Content-Type", equalTo("text/xml")));
 }
 ```
 
-For many more examples of JUnit tests look no further than [WireMock's
-own acceptance
-tests](https://github.com/tomakehurst/wiremock/tree/master/src/test/java/com/github/tomakehurst/wiremock)
-
-For more details on verifying requests and stubbing responses, see [Stubbing](../stubbing) and [Verifying](../verifying/)
-
-For more information on the JUnit rule see [The JUnit Rule](../junit-rule/).
-
-## Changing port numbers
+## Extend the test
 
 For a bit more control over the settings of the WireMock server created
-by the rule you can pass a fluently built Options object to either
-(non-deprecated) rule's constructor:
+by the rule you can pass a fluently built Options object to either rule's constructor.
+Let's change the port numbers as an example.
+
+### Change the port numbers
 
 ```java
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
@@ -94,8 +101,8 @@ public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089).
 ### Random port numbers
 
 You can have WireMock (or more accurately the JVM) pick random, free
-HTTP and HTTPS ports (which is a great idea if you want to run your
-tests concurrently):
+HTTP and HTTPS ports.
+It is a great idea if you want to run your tests concurrently.
 
 ```java
 @Rule
@@ -108,3 +115,10 @@ Then find out which ports to use from your tests as follows:
 int port = wireMockRule.port();
 int httpsPort = wireMockRule.httpsPort();
 ```
+
+## Further reading
+
+- For more details on verifying requests and stubbing responses, see [Stubbing](../../stubbing) and [Verifying](../../verifying/)
+- For more information on the JUnit rules see [The JUnit 4 Rule](../../junit-4/).
+- For many more examples of JUnit tests check out the
+[WireMock's own acceptance tests](https://github.com/wiremock/wiremock/tree/master/src/test/java/com/github/tomakehurst/wiremock)

--- a/_docs/standalone/admin-api-reference.md
+++ b/_docs/standalone/admin-api-reference.md
@@ -4,7 +4,9 @@ title: Admin API Reference
 meta_title: WireMock Admin REST API Documentation | WireMock
 toc_rank: 120
 description: The WireMock admin API is described in OpenAPI 3.0.
-redirect_from: "/wiremock-admin-api.html"
+redirect_from:
+    - "/wiremock-admin-api.html"
+    - "/docs/api"
 ---
 
 The WireMock admin API is described in [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md). The spec file plus an instance of Swagger UI can be accessed from a running WireMock instance under `/__admin/docs/`, e.g. `http://localhost:8080/__admin/docs/`.

--- a/_docs/standalone/administration.md
+++ b/_docs/standalone/administration.md
@@ -1,0 +1,24 @@
+---
+layout: docs
+title: Administration API
+meta_title: Administration API in WireMock Standalone | WireMock
+description: Provides tips on managing standalone WireMock servers
+---
+
+WireMock Standalone offers the REST API for administration, troubleshooting and analysis purposes.
+You can find the key use-cases and the full specification below.
+
+## Fetching all of your stub mappings (and checking WireMock is working)
+
+A GET request to the root admin URL e.g `http://localhost:8080/__admin`
+will return all currently registered stub mappings.
+This is a useful way to check whether WireMock is running on the host and port you expect.
+
+### Shutting Down
+
+To shutdown the server,
+post a request with an empty body to `http://<host>:<port>/__admin/shutdown`.
+
+## Full specification
+
+The full specification is available [here](../admin-api-reference).

--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -3,7 +3,9 @@ layout: docs
 title: Running as a Standalone Process
 meta_title: Run an API Mock Server as a Standalone Process | WireMock
 toc_rank: 41
-redirect_from: "/running-standalone.html"
+redirect_from: 
+    - "/running-standalone.html"
+    - "/docs/running-standalone.html"
 description: The WireMock server can be run in its own process, and configured via the Java API, JSON over HTTP or JSON files.
 ---
 


### PR DESCRIPTION
This change restructures the existing documentation to improve navigation, and to enable better learning path for newcomers. It also changes sections so that we can add more contents in the future

## Changes summary

- [x] - New Overview page
- [x] - Replace old "Getting Started" by the JUnit4 Tutorial and a listing of other tutorials including external ones
- [x] - Move rare use-cases to "Advanced": Java 1.7, running in servlet containers. We do not wont to promote them on the front
- [x] - Consolidate all WireMock Standalone docs in a dedicated section, prioritize the Docker use-case. Also add a page for administrative APIs overview
- [x] - Move Spring Boot and Android to "Java Usage" for now
- [x] - Revamp the navigation bar to  provide better structure

## New navbar

![image](https://user-images.githubusercontent.com/3000480/235442223-c1dbe214-d93f-4f32-a546-9c20aaa3756f.png)

## Old Navbar

![image](https://user-images.githubusercontent.com/3000480/235442251-21194ca1-0be2-4f27-8f82-7f80e74d27a8.png)

