### PR TITLE
Fix the positioning of the article links in External Resources

### DIFF
--- a/external-resources/index.html
+++ b/external-resources/index.html
@@ -46,6 +46,7 @@ description: Extensions, integrations, blog posts and videos about WireMock from
 
     <p>@GenerateWireMockStub for Spring REST controllers, built by Lukasz Gryzbon, makes the creation of WireMock stubs for tests safe and effortless:</p>
     <a href="https://github.com/lsd-consulting/spring-wiremock-stub-generator">https://github.com/lsd-consulting/spring-wiremock-stub-generator</a>
+
     <h4>
         Extensions
     </h4>
@@ -194,6 +195,10 @@ description: Extensions, integrations, blog posts and videos about WireMock from
 <a href="https://dzone.com/articles/wiremock-the-ridiculously-easy-way">
     https://dzone.com/articles/wiremock-the-ridiculously-easy-way
 </a>
+
+<p>
+    WireMock workshop:
+</p>
 
 <a href="https://github.com/basdijkstra/wiremock-workshop">
     https://github.com/basdijkstra/wiremock-workshop


### PR DESCRIPTION
It appears the recent change to add a link to the https://dzone.com/articles/wiremock-the-ridiculously-easy-way article, messed up the positioning of the WireMock Workshop link:

![image](https://user-images.githubusercontent.com/5703054/235633615-e8a8e4eb-d1dd-4743-b53a-c1c5308b38d0.png)

Hopefully, this PR fixes it.