### PR TITLE
Update Google Analytics to use gtag, disable non-production analytics

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,7 +54,7 @@ jobs:
           mkdir _site/3.x
           cp -R tmp/site_3x/* _site/3.x/
         env:
-          JEKYLL_ENV: 3.x
+          JEKYLL_ENV: production
 # TODO: Uncomment when cleaned up (if ever)
 #      - name: Validate HTML and links
 #        uses: anishathalye/proof-html@v2

--- a/_config.yml
+++ b/_config.yml
@@ -53,8 +53,7 @@ social:
 analytics:
     provider: google
     google:
-        tracking_id: "UA-36386229-2"
-        optimize_id: "GTM-WQTGSSM"
+        id: "G-KN208QTJLZ"
 
 # Google AdSense
 google_ad_client:

--- a/_includes/analytics-providers/google.html
+++ b/_includes/analytics-providers/google.html
@@ -1,19 +1,9 @@
 <!-- Google Analytics -->
-<style>.async-hide { opacity: 0 !important} </style>
-<!--<script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;-->
-  <!--h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};-->
-  <!--(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;-->
-<!--})(window,document.documentElement,'async-hide','dataLayer',4000,-->
-  <!--{'{{ site.analytics.google.optimize_id }}':true});</script>-->
-
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.id }}"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-  ga('create', '{{ site.analytics.google.tracking_id }}', 'auto');
-  ga('require', '{{ site.analytics.google.optimize_id }}');
-  ga('send', 'pageview');
+  gtag('config', '{{ site.analytics.google.id }}');
 </script>
-<!-- End Google Analytics -->

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,4 +1,4 @@
-{% if site.analytics.provider and page.analytics != false %}
+{% if site.analytics.provider and page.analytics != false and jekyll.environment == "production" %}
 
 {% case site.analytics.provider %}
 {% when "google" %}


### PR DESCRIPTION
- The Analytics will stop working if not fixed
- Also, disables analytics when not running in the production environment - fixes #35 