### PR TITLE
Restore UA analytics to the old property

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -53,7 +53,12 @@ social:
 analytics:
     provider: google
     google:
+        # gtag
         id: "G-KN208QTJLZ"
+        # Google Analytics
+        # TODO: Remove once disabled on 15 July
+        tracking_id: "UA-36386229-2"
+        optimize_id: "GTM-WQTGSSM"
 
 # Google AdSense
 google_ad_client:

--- a/_includes/analytics-providers/google.html
+++ b/_includes/analytics-providers/google.html
@@ -1,4 +1,6 @@
 <!-- Google Analytics -->
+
+<!-- gtag -->
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.analytics.google.id }}"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
@@ -7,3 +9,18 @@
 
   gtag('config', '{{ site.analytics.google.id }}');
 </script>
+
+<!--
+Old submission to another property using UA
+TODO: Delete once analytics is EoL
+-->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  ga('create', '{{ site.analytics.google.tracking_id }}', 'auto');
+  ga('require', '{{ site.analytics.google.optimize_id }}');
+  ga('send', 'pageview'); 
+</script>
+<!-- End Google Analytics -->


### PR DESCRIPTION
Apparently, the previous analytics engine was connected somewhere instead of what I heard. Restored it so that @tomakehurst could review the status and share access to the property