### PR TITLE
Update navlinks in the hamburger menu

### DIFF
--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -144,19 +144,19 @@
       <div class="mobile-menu-wrapper">
         <img id="closeMenuIcon" class="closeMenuIcon" src="{{ '/images/closeMenuIcon.svg' | absolute_url }}" />
         <ul>
-          <li><a href="{{ '/docs' | absolute_url }}">Open Source docs</a></li>
+          <li><a href="{{ '/docs' | absolute_url }}">Documentation</a></li>
           <li>
             <a href="https://wiremock.io?utm_source=wiremock.org&utm_medium=masthead&utm_campaign=homepage_2022_baseline" title="WireMock Cloud">
               <img src="{{ '/images/wiremock-cloud/wiremock_cloud_logo.png' | absolute_url }}" alt="WireMock Cloud" style="vertical-align: middle;height: 28px"/><br>
-              WireMock Cloud docs
+              WireMock Cloud
             </a>
           </li>
-          <li><a href="{{ '/studio/docs' | absolute_url }}">WireMock Studio docs</a></li>
           
-          <li><a href="{{ '/support' | absolute_url }}">Support</a></li>
+          <li><a href="{{ '/support' | absolute_url }}">Need Help?</a></li>
+          <li><a href="https://slack.wiremock.org/" target="_blank">Community Slack</a></li>
           <li><a href="https://github.com/wiremock/wiremock" target="_blank">GitHub</a></li>
-          <li><a href="https://github.com/wiremock/wiremock/blob/master/CONTRIBUTING.md" target="_blank">Contributing</a></li>
-          <li><a href="{{ '/external-resources' | absolute_url }}">Resources</a></li>
+          <li><a href="https://twitter.com/wiremockorg">Twitter</a></li>
+          <li><a href="https://github.com/wiremock/community/blob/main/contributing/README.md" target="_blank">Contributing</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Cleans up the hamburger menu, esp on mobile:

- Remove WireMock Studio link - for #27 
- Add Slack and Twitter links
- Align wording of other entries