### PR TITLE
Landing changes - low hanging fruit

### DIFF
--- a/_docs/download-and-installation.md
+++ b/_docs/download-and-installation.md
@@ -12,6 +12,9 @@ WireMock plus all its dependencies.
 Most of the standalone JAR's dependencies are shaded i.e. they are hidden in alternative packages. This allows WireMock to be used in projects with
 conflicting versions of its dependencies. The standalone JAR is also runnable (see [Running as a Standalone Process](../running-standalone/)).
 
+
+
+
 ## 3.x beta
 
 Maven:

--- a/_docs/download-and-installation.md
+++ b/_docs/download-and-installation.md
@@ -3,32 +3,31 @@ layout: docs
 title: Download and Installation
 meta_title: "How to Download and Install WireMock"
 toc_rank: 13
-description: WireMock is distributed in two flavours - a standard JAR containing just WireMock, and a standalone fat JAR containing WireMock plus all its dependencies.
+description: >
+    WireMock is available as a standalone service (for Docker of Java), Java library
+    and integrations for modern languages and technology stacks.
 ---
 
-WireMock is distributed in two flavours - a standard JAR containing just WireMock, and a standalone uber JAR containing
+
+## Download options
+
+WireMock Java is distributed in two flavours - a standard JAR containing just WireMock, and a standalone uber JAR containing
 WireMock plus all its dependencies.
 
 Most of the standalone JAR's dependencies are shaded i.e. they are hidden in alternative packages. This allows WireMock to be used in projects with
 conflicting versions of its dependencies. The standalone JAR is also runnable (see [Running as a Standalone Process](../running-standalone/)).
 
+## Test dependencies
 
+<div class="downloads-wrapper">
+    {% include downloads.html %}
+</div>
 
+## Standalone Service
 
-## 3.x beta
+### WireMock 3.x Beta (recommended)
 
-Maven:
-
-```xml
-<dependency>
-    <groupId>com.github.tomakehurst</groupId>
-    <artifactId>wiremock</artifactId>
-    <version>{{ site.wiremock_beta_version }}</version>
-    <scope>test</scope>
-</dependency>
-```
-
-Maven (standalone):
+#### Maven
 
 ```xml
 <dependency>
@@ -39,34 +38,28 @@ Maven (standalone):
 </dependency>
 ```
 
-Gradle:
-
-```groovy
-testImplementation "com.github.tomakehurst:wiremock:{{ site.wiremock_beta_version }}"
-```
-
-Gradle (standalone):
+#### Gradle
 
 ```groovy
 testImplementation "com.github.tomakehurst:wiremock-standalone:{{ site.wiremock_beta_version }}"
 ```
 
+### Stable
 
+#### Docker
 
-## Stable
+Run the following in a terminal:
 
-Maven:
-
-```xml
-<dependency>
-    <groupId>com.github.tomakehurst</groupId>
-    <artifactId>wiremock-jre8</artifactId>
-    <version>{{ site.wiremock_version }}</version>
-    <scope>test</scope>
-</dependency>
+```bash
+docker run -it --rm \
+  -p 8080:8080 \
+  --name wiremock \
+  wiremock/wiremock:{{ site.wiremock_version }}
 ```
 
-Maven (standalone):
+Learn more in the [Docker guide](../docker).
+
+#### Maven - stable
 
 ```xml
 <dependency>
@@ -77,13 +70,7 @@ Maven (standalone):
 </dependency>
 ```
 
-Gradle:
-
-```groovy
-testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
-```
-
-Gradle (standalone):
+#### Gradle - stable
 
 ```groovy
 testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wiremock_version }}"

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -1,0 +1,142 @@
+<!-- Lists WireMock download options -->
+<style>
+  
+.codeTabDescription {
+    margin: 0px;
+    padding: 0px;
+    font-family: "Ubuntu";
+    font-style: normal;
+    font-weight: normal;
+    font-size: 16px;
+    color: #000;
+}
+
+.code-tabs-main-example {
+  padding: 30px;
+}
+
+.code-tabs-main-example .highlight {
+  background: #F0F5FF;
+  border: 1px solid #D2DFF9;
+  box-sizing: border-box;
+  border-radius: 8px;
+}
+
+.codeSnippet {
+  display: none;
+  width: 100%;
+  position: relative;
+}
+
+.codeSnippet.activeCodeSnippet {
+  display: block;
+}
+
+.code-tabs-main {
+  width: 1018px;
+}
+
+@media (max-width:670px) {
+  .code-tabs-main {
+    width: 100% !important;
+  }
+}
+</style>
+
+<div id="open-source-get-started" class="container code-tabs-wrapper">
+    <div class="code-tabs-row">
+      <div class="code-tabs-sidebar-wrapper">
+        <div class="code-tabs-sidebar">
+          <div class="code-tabs-example-card">
+            <img src="{{ '/images/maven.png' | absolute_url }}" alt="Maven" />
+          </div>
+          <div class="code-tabs-example-card">
+            <img src="{{ '/images/elephantIcon.png' | absolute_url }}" alt="Gradle"/>
+          </div>
+          <div class="code-tabs-example-card">
+            <img src="{{ '/images/kotlin.png' | absolute_url }}" alt="Kotlin" />
+          </div>
+          <div class="code-tabs-example-card">
+            <img src="{{ '/images/sbt.png ' | absolute_url }}" alt="SBT"/>
+          </div>
+          {% if include.show_standalone %}
+          <div class="code-tabs-example-card">
+            <img src="{{ '/images/java.png ' | absolute_url }}" alt="Java"/>
+          </div>
+          <div class="code-tabs-example-card">
+            <img src="{{ '/images/docker.png ' | absolute_url }}" alt="Docker"/>
+          </div>
+          {% endif %}
+        </div>
+      </div>
+      <div class="code-tabs-main">
+        <div class="code-tabs-main-wrapper">
+          <ul>
+            <li class="active-tab-example">Maven</li>
+            <li>Gradle Groovy</li>
+            <li>Gradle Kotlin</li>
+            <li>Scala SBT</li>
+            {% if include.show_standalone %}
+            <li>Standalone</li>
+            <li>Docker</li>
+            {% endif %}
+          </ul>
+          <div class="code-tabs-main-example">
+            <div class="codeSnippet activeCodeSnippet" data-snippettab="maven">
+              <p class="codeTabDescription">Add the following to your project's <strong>pom.xml</strong> dependencies:</p>
+{% highlight xml %}
+<dependency>
+  <groupId>com.github.tomakehurst</groupId>
+  <artifactId>wiremock-jre8</artifactId>
+  <version>{{ site.wiremock_version }}</version>
+  <scope>test</scope>
+</dependency>
+{% endhighlight %}
+            <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="docs/junit-jupiter/">JUnit 5+</a> or <a href="docs/java-usage/">plain Java</a>.</p>
+          </div>
+          <div class="codeSnippet" data-snippettab="gradle groovy">
+            <p class="codeTabDescription">Add the following to your project's <strong>build.gradle</strong>:</p>
+{% highlight groovy %}
+testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
+{% endhighlight %}
+            <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="docs/junit-jupiter/">JUnit 5+</a> or <a href="docs/java-usage/">plain Java</a>.</p>
+          </div>
+          <div class="codeSnippet" data-snippettab="gradle kotlin">
+            <p class="codeTabDescription">Add the following to your project's <strong>build.gradle.kts</strong>:</p>
+{% highlight kotlin %}
+testImplementation("com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}")
+{% endhighlight %}
+            <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="docs/junit-jupiter/">JUnit 5+</a> or <a href="docs/java-usage/">plain Java</a>.</p>
+          </div>
+          <div class="codeSnippet" data-snippettab="scala sbt">
+            <p class="codeTabDescription">Add the following to your project’s <strong>build.sbt</strong>:</p>
+{% highlight scala %}
+libraryDependencies +=
+  "com.github.tomakehurst" % "wiremock-jre8" % "{{ site.wiremock_version }}" % Test
+{% endhighlight %}
+          </div>
+          <div class="codeSnippet" data-snippettab="standalone">
+            <p class="codeTabDescription">
+              Download the <a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/{{ site.wiremock_version }}/wiremock-jre8-standalone-{{ site.wiremock_version }}.jar">latest standalone JAR</a>
+              then run the following in a terminal:
+            </p>
+{% highlight bash %}
+java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar
+{% endhighlight %}
+            <p class="codeTabDescription" style="margin-top:2rem;">Learn more in the <a href="docs/running-standalone/">running standalone guide.</a></p>
+          </div>
+          <div class="codeSnippet" data-snippettab="docker">
+            <p class="codeTabDescription">Run the following in a terminal:</p>
+{% highlight bash %}
+docker run -it --rm \
+  -p 8080:8080 \
+  --name wiremock \
+  wiremock/wiremock:{{ site.wiremock_version }}
+{% endhighlight %}
+            <p class="codeTabDescription" style="margin-top:2rem;">Learn more in the <a href="docs/docker/">Docker guide.</a></p>
+          </div>
+        </div>
+        </div>
+      </div>
+    </div>
+</div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,6 @@
 
 <script src="{{ '/assets/js/mobile-navbar.js' | absolute_url }}"></script>
 <script src="{{ '/assets/js/codeTab.js' | absolute_url }}"></script>
-
 <script src="{{ '/assets/js/sidebar-docs.js' | absolute_url }}"></script>
 <script src="{{ '/assets/js/tracking-events.js' | absolute_url }}"></script>
 <script src="{{ '/assets/js/faq.js' | absolute_url }}"></script>

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -346,7 +346,6 @@ html {
 }
 
 .code-tabs-wrapper {
-    margin-top: 70px;
     margin-bottom: 70px;
     background-color: $general-background;
     border-radius: 50px;
@@ -684,7 +683,7 @@ html {
     .keyFeaturesInfo {
         text-align: center;
         padding-top: 20px;
-        padding-bottom: 90px;
+        padding-bottom: 30px;
         max-width: 1150px;
         margin: 0 auto;
     }
@@ -729,7 +728,8 @@ html {
     .key-features-btn-full {
         display: flex;
         justify-content: center;
-        padding-top: 90px;
+        padding-top: 20px;
+        padding-bottom: 40px;       
     }
 }
 

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -157,6 +157,7 @@ html {
     }
     
     padding: 40px;
+    padding-bottom: 10px;
 
     h1 {
         font-family: "Ubuntu";

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -733,6 +733,18 @@ html {
     }
 }
 
+.downloads-wrapper {
+    background: rgba(240, 245, 255, 0.5);
+    padding: 70px 0;
+    padding-bottom: 20px;
+}
+
+.faq-wrapper {
+    background: white;
+    padding: 70px 0;
+    padding-bottom: 20px;
+}
+
 .apis-wrapper {
     padding: 70px 0;
     display: flex;

--- a/_sass/_homepage.scss
+++ b/_sass/_homepage.scss
@@ -734,13 +734,13 @@ html {
 }
 
 .downloads-wrapper {
-    background: rgba(240, 245, 255, 0.5);
+    background: white;
     padding: 70px 0;
     padding-bottom: 20px;
 }
 
 .faq-wrapper {
-    background: white;
+    background: rgba(240, 245, 255, 0.5);
     padding: 70px 0;
     padding-bottom: 20px;
 }

--- a/index.html
+++ b/index.html
@@ -216,12 +216,12 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
       </p>
     </div>
   </div>
-  <div class="container key-features-btn-full">
+  <div class="key-features-btn-full">
     <a class="btn-card-info btnGetStarted" href="docs/">Full Documentation</a>
   </div>
 
 
-  <div class="container">
+  <div class="downloads-wrapper">
   <h2 class="keyFeaturesTXT">Downloads</h2>
   <p class="keyFeaturesInfo">WireMock is available as a standalone service, Java library
     and integrations for modern languages and technology stacks.</p>
@@ -347,6 +347,7 @@ docker run -it --rm \
   </div>
   </div>
 
+  <div class="faq-wrapper">
     <div class="container faq">
       <h2 class="keyFeaturesTXT">FAQ</h2>
       <dl class="faq-list">
@@ -372,4 +373,5 @@ docker run -it --rm \
         <dd>WireMock is completely free under the Apache 2.0 license.</dd>
       </dl>
     </div>
+  </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -52,9 +52,19 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
   }
 }
 
-  #a-wiremock-cloud {
-    display: none;
+#a-wiremock-cloud {
+  display: none;
+}
+
+.summary-header-stats {
+  display: flex;
+  align-items: center;
+  margin-left: 20px;
+
+  >a {
+      padding-left: 10px;
   }
+}
 
 </style>
 
@@ -63,16 +73,41 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
   <div class="container home-header-container">
     <div class="home-header-hero-text">
       <h1>WireMock - flexible API mocking</h1>
-      <h2>Free and Open Source</h2>
-      <p>The flexible tool for building mock APIs.</p>
+      
+      <div class="summary-header-stats">
+          <a href="https://github.com/wiremock/wiremock/stargazers" target="_blank">
+            <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/wiremock/wiremock?style=social" >
+          </a>
+          <a href="https://github.com/wiremock/wiremock" target="_blank">
+            <img alt="GitHub forks" src="https://img.shields.io/github/forks/wiremock/wiremock?style=social" >
+          </a>
+          <a href="https://github.com/wiremock/" target="_blank">
+            <img alt="Downloads" src="https://img.shields.io/badge/Downloads-5M%2B%20%2F%20month-white?style=social" >
+          </a>
+          <a href="https://github.com/wiremock/" target="_blank">
+            <img alt="Contributors" src="https://img.shields.io/badge/Contributors-279-white?style=social&logo=github" >
+          </a>
+
+          <!-- Automate pulling with fancy style
+          <a href="https://github.com/wiremock/" target="_blank">
+            <img alt="Contributors" src="https://cauldron.io/project/7478/export/svg/git_contributors.svg" >
+          </a>
+          -->
+      </div>
+
+
+      <p>Free and Open Source tool for building mock APIs.
+         Create stable development environments, isolate yourself from flakey 3rd parties and simulate APIs that don't exist yet.
+      </p>
       <p>
-        Create stable development environments, isolate yourself from flakey 3rd parties and simulate APIs that don't exist yet.
+        Available as a standalone service, Java lib and integrations for modern languages and technology stacks. 
       </p>
 
       <div style="margin-top: 40px;display:flex;flex-wrap:wrap;gap: 5px;">
-        <a href="#open-source-get-started" class="btn-primary">Get started</a>
-        <a href="{{ '/docs/' | absolute_url }}" class="btn-secondary">View docs</a>
-        <a href="{{ site.community_slack.join_url | absolute_url }}" class="btn-secondary">Slack community</a>
+
+        <a href="{{ '/docs/' | absolute_url }}" class="btn-primary">Get Started</a>
+        <a href="{{ '/docs/download-and-installation/' | absolute_url }}" class="btn-secondary">Downloads</a>
+        <a href="{{ site.community_slack.join_url | absolute_url }}" class="btn-secondary">Slack Community</a>
       </div>
     </div>
     <div class="home-header-hero-image">
@@ -89,7 +124,6 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
     "method": "GET",
     "url": "/wiremock"
   },
-
   "response": {
     "status": 200,
     "body": "Easy!"

--- a/index.html
+++ b/index.html
@@ -99,9 +99,6 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
       <p>Free and Open Source tool for building mock APIs.
          Create stable development environments, isolate yourself from flakey 3rd parties and simulate APIs that don't exist yet.
       </p>
-      <p>
-        Available as a standalone service, Java lib and integrations for modern languages and technology stacks. 
-      </p>
 
       <div style="margin-top: 40px;display:flex;flex-wrap:wrap;gap: 5px;">
 
@@ -162,6 +159,72 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
       </div>
   </div>
 </div>
+
+<div class="key-features-wrapper">
+  <h2 class="keyFeaturesTXT">Key Features</h2>
+  <p class="keyFeaturesInfo">WireMock frees you from dependency on unstable APIs and allows you to develop with confidence. It's easy to launch a mock API server and simulate a host of real-world scenarios and APIs - including REST, SOAP, OAuth2 and more.</p>
+  <div class="container key-features-grid">
+    <div class="key-features-card">
+      <img src="{{ '/images/requestIcon.svg' | absolute_url }}" alt="Wiremock Features"/>
+      <p>
+        Advanced request
+      </p>
+      <p>
+        matching
+      </p>
+    </div>
+    <div class="key-features-card">
+      <img src="{{ '/images/responseIcon.svg' | absolute_url }}" alt="wiremock dynamic response"/>
+      <p>
+        Dynamic response
+      </p>
+      <p>
+        templating
+      </p>
+    </div>
+    <div class="key-features-card">
+      <img src="{{ '/images/unitTestIcon.svg' | absolute_url }}" alt="wiremock unit tests" />
+      <p>
+        Run in your unit tests, on your
+      </p>
+      <p>
+        laptop or in your test environment.
+      </p>
+    </div>
+    <div class="key-features-card">
+      <img src="{{ '/images/faultIcon.svg' | absolute_url }}" alt="wiremock fault and latency"/>
+      <p>
+        Fault and latency
+      </p>
+      <p>
+        injection
+      </p>
+    </div>
+    <div class="key-features-card">
+      <img src="{{ '/images/recordIcon.svg' | absolute_url }}" alt="wiremock record playback"/>
+      <p>
+        Record / Playback
+      </p>
+    </div>
+    <div class="key-features-card">
+      <img src="{{ '/images/httpIcon.svg' | absolute_url }}" alt="wiremock java, python, http" />
+      <p>
+        Java, Python, HTTP and
+      </p>
+      <p>
+        JSON file APIs
+      </p>
+    </div>
+  </div>
+  <div class="container key-features-btn-full">
+    <a class="btn-card-info btnGetStarted" href="docs/">Full Documentation</a>
+  </div>
+
+
+  <div class="container">
+  <h2 class="keyFeaturesTXT">Downloads</h2>
+  <p class="keyFeaturesInfo">WireMock is available as a standalone service, Java library
+    and integrations for modern languages and technology stacks.</p>
 
   <div id="open-source-get-started" class="container code-tabs-wrapper">
     <div class="code-tabs-row">
@@ -282,69 +345,10 @@ docker run -it --rm \
       </a>
     </div>
   </div>
-
-<div class="key-features-wrapper">
-    <h2 class="keyFeaturesTXT">Key Features</h2>
-    <p class="keyFeaturesInfo">WireMock frees you from dependency on unstable APIs and allows you to develop with confidence. It's easy to launch a mock API server and simulate a host of real-world scenarios and APIs - including REST, SOAP, OAuth2 and more.</p>
-    <div class="container key-features-grid">
-      <div class="key-features-card">
-        <img src="{{ '/images/requestIcon.svg' | absolute_url }}" alt="Wiremock Features"/>
-        <p>
-          Advanced request
-        </p>
-        <p>
-          matching
-        </p>
-      </div>
-      <div class="key-features-card">
-        <img src="{{ '/images/responseIcon.svg' | absolute_url }}" alt="wiremock dynamic response"/>
-        <p>
-          Dynamic response
-        </p>
-        <p>
-          templating
-        </p>
-      </div>
-      <div class="key-features-card">
-        <img src="{{ '/images/unitTestIcon.svg' | absolute_url }}" alt="wiremock unit tests" />
-        <p>
-          Run in your unit tests, on your
-        </p>
-        <p>
-          laptop or in your test environment.
-        </p>
-      </div>
-      <div class="key-features-card">
-        <img src="{{ '/images/faultIcon.svg' | absolute_url }}" alt="wiremock fault and latency"/>
-        <p>
-          Fault and latency
-        </p>
-        <p>
-          injection
-        </p>
-      </div>
-      <div class="key-features-card">
-        <img src="{{ '/images/recordIcon.svg' | absolute_url }}" alt="wiremock record playback"/>
-        <p>
-          Record / Playback
-        </p>
-      </div>
-      <div class="key-features-card">
-        <img src="{{ '/images/httpIcon.svg' | absolute_url }}" alt="wiremock java, python, http" />
-        <p>
-          Java, Python, HTTP and
-        </p>
-        <p>
-          JSON file APIs
-        </p>
-      </div>
-    </div>
-    <div class="container key-features-btn-full">
-      <a class="btn-card-info btnGetStarted" href="docs/">Full Documentation</a>
-    </div>
+  </div>
 
     <div class="container faq">
-      <h2>FAQ</h2>
+      <h2 class="keyFeaturesTXT">FAQ</h2>
       <dl class="faq-list">
         <dt><i class="faq-list-arrow"></i> What is WireMock?</dt>
         <dd>WireMock is a free API mocking tool that can be run as a standalone server, or in a hosted version via the <a href="https://wiremock.io/">WireMock Cloud</a> managed service.</dd>

--- a/index.html
+++ b/index.html
@@ -11,47 +11,6 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
     padding: 0 !important;
 }
 
-.codeTabDescription {
-    margin: 0px;
-    padding: 0px;
-    font-family: "Ubuntu";
-    font-style: normal;
-    font-weight: normal;
-    font-size: 16px;
-    color: #000;
-}
-
-.code-tabs-main-example {
-  padding: 30px;
-}
-
-.code-tabs-main-example .highlight {
-  background: #F0F5FF;
-  border: 1px solid #D2DFF9;
-  box-sizing: border-box;
-  border-radius: 8px;
-}
-
-.codeSnippet {
-  display: none;
-  width: 100%;
-  position: relative;
-}
-
-.codeSnippet.activeCodeSnippet {
-  display: block;
-}
-
-.code-tabs-main {
-  width: 1018px;
-}
-
-@media (max-width:670px) {
-  .code-tabs-main {
-    width: 100% !important;
-  }
-}
-
 #a-wiremock-cloud {
   display: none;
 }
@@ -222,129 +181,13 @@ description: WireMock is a tool for building mock APIs. API mocking enables you 
 
 
   <div class="downloads-wrapper">
-  <h2 class="keyFeaturesTXT">Downloads</h2>
-  <p class="keyFeaturesInfo">WireMock is available as a standalone service, Java library
-    and integrations for modern languages and technology stacks.</p>
-
-  <div id="open-source-get-started" class="container code-tabs-wrapper">
-    <div class="code-tabs-row">
-      <div class="code-tabs-sidebar-wrapper">
-        <div class="code-tabs-sidebar">
-          <div class="code-tabs-example-card">
-            <img src="{{ '/images/maven.png' | absolute_url }}" alt="Maven" />
-          </div>
-          <div class="code-tabs-example-card">
-            <img src="{{ '/images/elephantIcon.png' | absolute_url }}" alt="Gradle"/>
-          </div>
-          <div class="code-tabs-example-card">
-            <img src="{{ '/images/kotlin.png' | absolute_url }}" alt="Kotlin" />
-          </div>
-          <div class="code-tabs-example-card">
-            <img src="{{ '/images/sbt.png ' | absolute_url }}" alt="SBT"/>
-          </div>
-          <div class="code-tabs-example-card">
-            <img src="{{ '/images/java.png ' | absolute_url }}" alt="Java"/>
-          </div>
-          <div class="code-tabs-example-card">
-            <img src="{{ '/images/docker.png ' | absolute_url }}" alt="Docker"/>
-          </div>
-        </div>
-      </div>
-      <div class="code-tabs-main">
-        <div class="code-tabs-main-wrapper">
-          <ul>
-            <li class="active-tab-example">Maven</li>
-            <li>Gradle Groovy</li>
-            <li>Gradle Kotlin</li>
-            <li>Scala SBT</li>
-            <li>Standalone</li>
-            <li>Docker</li>
-          </ul>
-          <div class="code-tabs-main-example">
-            <div class="codeSnippet activeCodeSnippet" data-snippettab="maven">
-              <p class="codeTabDescription">Add the following to your project's <strong>pom.xml</strong> dependencies:</p>
-{% highlight xml %}
-<dependency>
-  <groupId>com.github.tomakehurst</groupId>
-  <artifactId>wiremock-jre8</artifactId>
-  <version>{{ site.wiremock_version }}</version>
-  <scope>test</scope>
-</dependency>
-{% endhighlight %}
-            <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="docs/junit-jupiter/">JUnit 5+</a> or <a href="docs/java-usage/">plain Java</a>.</p>
-          </div>
-          <div class="codeSnippet" data-snippettab="gradle groovy">
-            <p class="codeTabDescription">Add the following to your project's <strong>build.gradle</strong>:</p>
-{% highlight groovy %}
-testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
-{% endhighlight %}
-            <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="docs/junit-jupiter/">JUnit 5+</a> or <a href="docs/java-usage/">plain Java</a>.</p>
-          </div>
-          <div class="codeSnippet" data-snippettab="gradle kotlin">
-            <p class="codeTabDescription">Add the following to your project's <strong>build.gradle.kts</strong>:</p>
-{% highlight kotlin %}
-testImplementation("com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}")
-{% endhighlight %}
-            <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="docs/junit-jupiter/">JUnit 5+</a> or <a href="docs/java-usage/">plain Java</a>.</p>
-          </div>
-          <div class="codeSnippet" data-snippettab="scala sbt">
-            <p class="codeTabDescription">Add the following to your project’s <strong>build.sbt</strong>:</p>
-{% highlight scala %}
-libraryDependencies +=
-  "com.github.tomakehurst" % "wiremock-jre8" % "{{ site.wiremock_version }}" % Test
-{% endhighlight %}
-          </div>
-          <div class="codeSnippet" data-snippettab="standalone">
-            <p class="codeTabDescription">
-              Download the <a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/{{ site.wiremock_version }}/wiremock-jre8-standalone-{{ site.wiremock_version }}.jar">latest standalone JAR</a>
-              then run the following in a terminal:
-            </p>
-{% highlight bash %}
-java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar
-{% endhighlight %}
-            <p class="codeTabDescription" style="margin-top:2rem;">Learn more in the <a href="docs/running-standalone/">running standalone guide.</a></p>
-          </div>
-          <div class="codeSnippet" data-snippettab="docker">
-            <p class="codeTabDescription">Run the following in a terminal:</p>
-{% highlight bash %}
-docker run -it --rm \
-  -p 8080:8080 \
-  --name wiremock \
-  wiremock/wiremock:{{ site.wiremock_version }}
-{% endhighlight %}
-            <p class="codeTabDescription" style="margin-top:2rem;">Learn more in the <a href="docs/docker/">Docker guide.</a></p>
-          </div>
-        </div>
-        </div>
-      </div>
-    </div>
-    <div class="code-tabs-footer">
-
-      <div class="ct-github-info-wrapper">
-
-        <div class="github-card-info-wrapper">
-          <div class="github-card-info">
-            <a href="https://github.com/wiremock/wiremock/stargazers" target="_blank">
-              <img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/wiremock/wiremock?style=social" >
-            </a>
-          </div>
-        </div>
-
-        <div class="github-card-info-wrapper">
-          <div class="github-card-info">
-            <a href="https://github.com/wiremock/wiremock" target="_blank">
-              <img alt="GitHub forks" src="https://img.shields.io/github/forks/wiremock/wiremock?style=social" >
-            </a>
-          </div>
-        </div>
-
-      </div>
-      <a href="https://github.com/wiremock/wiremock" class="ctDownloadBTN" target="_blank">
-        <img src="{{ '/images/ctGithubDownloadIcon.svg' | absolute_url }}" />
-        <span>View Repo</span>
-      </a>
-    </div>
-  </div>
+    <h2 class="keyFeaturesTXT">Downloads</h2>
+    <p class="keyFeaturesInfo">WireMock is available as a standalone service, Java library
+      and integrations for modern languages and technology stacks.
+    </p>
+      
+    {% include downloads.html show_standalone="true" %}
+  
   </div>
 
   <div class="faq-wrapper">


### PR DESCRIPTION
This change improves the navigation on the website

- [x] Shorten the header, add badges there
- [x] Move features above downloads
- [x] Improve styling to decrease vertical size 
- [x] Point users to the root documentation, not to Maven pull
- [x] Modify the downloads page to keep it simple, reuse downloads selector 

## Landing

![localhost_4000_](https://github.com/wiremock/wiremock.org/assets/3000480/03953e6b-af7f-406f-8553-c2d80099813a)



## Downloads

![localhost_4000_docs_download-and-installation_](https://github.com/wiremock/wiremock.org/assets/3000480/2ea93999-c36d-42d7-ad85-3e6504973751)

