### PR TITLE
Fix the WireMock 3.x content inclusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
+          # No longer a default
           submodules: recursive
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,9 @@ jobs:
           JEKYLL_ENV: development
       - name: Build 3.x with Jekyll
         # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --config '_config.yml,_config-3.x.yml' --baseurl "${{ steps.pages.outputs.base_path }}/3.x"
+        run: |
+          cd ./submodules/wiremock.org-3.x
+          bundle exec jekyll build --config '_config.yml,_config-3.x.yml' --baseurl "${{ steps.pages.outputs.base_path }}/3.x"
         env:
           JEKYLL_ENV: development
 # TODO: Uncomment when cleaned up (if ever)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -49,10 +49,16 @@ jobs:
       - name: Build 3.x with Jekyll
         # Outputs to the './_site' directory by default
         run: |
+          cd ./submodules/wiremock.org-3.x
           bundle exec jekyll build --config '_config.yml,_config-3.x.yml' --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Deploy 3.x to the website
+        # Outputs to the './_site' directory by default
+        run: |
           ruby .scripts/merge-sitemaps.rb
           mkdir _site/3.x
-          cp -R tmp/site_3x/* _site/3.x/
+          cp -R ./submodules/wiremock.org-3.x/tmp/site_3x/* _site/3.x/
         env:
           JEKYLL_ENV: production
 # TODO: Uncomment when cleaned up (if ever)

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Setup Ruby
         uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
         with:

--- a/.scripts/merge-sitemaps.rb
+++ b/.scripts/merge-sitemaps.rb
@@ -7,7 +7,7 @@ File.open( "_site/sitemap.xml", 'r' ) do |f1|
     footer = [ content1.slice!( -1 ) ]
 end
 
-File.open( "tmp/site_3x/sitemap.xml", 'r' ) do |f2|
+File.open( "./submodules/wiremock.org-3.x/tmp/site_3x/sitemap.xml", 'r' ) do |f2|
     content2 = (IO.readlines f2)
     content2.slice!( 0..11 )
     content2.slice!( -1 ) 


### PR DESCRIPTION
As reported by @tomakehurst , 3.x does not actually include the 3.x content after I restructured the repository and stopped doing git checkout magic