### PR TITLE
Fix Liquid warning in the single layout from the template

### DIFF
--- a/_layouts/single.html
+++ b/_layouts/single.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-{% if (page.header.overlay_color or page.header.overlay_image) or page.header.image %}
+{% if page.header.overlay_color or page.header.overlay_image or page.header.image %}
   {% include page__hero.html %}
 {% endif %}
 


### PR DESCRIPTION
IMHO it is a Liquid bug but easier to just get rid of it in our code

```
C:/Ruby27-x64/lib/ruby/gems/2.7.0/gems/json-1.8.6/lib/json/common.rb:155: warning: Using the last argument as keyword parameters is deprecated
    Liquid Warning: Liquid syntax error (line 1): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in C:/Users/Oleg/Documents/opensource/wiremock/wiremock.org/_layouts/splash.html
    Liquid Warning: Liquid syntax error (line 1): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in C:/Users/Oleg/Documents/opensource/wiremock/wiremock.org/_layouts/single.html
    Liquid Warning: Liquid syntax error (line 1): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in C:/Users/Oleg/Documents/opensource/wiremock/wiremock.org/_layouts/archive.html
    Liquid Warning: Liquid syntax error (line 1): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in C:/Users/Oleg/Documents/opensource/wiremock/wiremock.org/_layouts/support.html
```

https://github.com/mmistakes/minimal-mistakes/issues/479. Contributes to #58 