### PR TITLE
Doc rendering SCSS bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
     sass-embedded (1.62.1)
       google-protobuf (~> 3.21)
       rake (>= 10.0.0)
+    sass-embedded (1.62.1-x64-mingw32)
+      google-protobuf (~> 3.21)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -108,6 +110,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
+    wdm (0.1.1)
     webrick (1.8.1)
 
 PLATFORMS
@@ -125,6 +128,7 @@ DEPENDENCIES
   jemoji
   json (~> 1.8.6)
   nokogiri (>= 1.7.2)
+  wdm (~> 0.1.0)
   webrick (~> 1.7)
 
 BUNDLED WITH

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -23,8 +23,8 @@
 .page {
     @include breakpoint($large) {
         @include span(10 of 12 last);
-        @include prefix(0.5 of 12);
-        @include suffix(2 of 12);
+        @include prefix(0.1 of 12);
+        @include suffix(1 of 12);
     }
 
     .page__inner-wrap {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The CSS issue for document landing page for mobile devices fixed. Columns reduce on reducing screen size.
## References

- TODO
https://github.com/wiremock/wiremock.org/issues/95
<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] The repository's code style is followed (see the contributing guide)
- [ ] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
