### PR TITLE
Reference the target branch in the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@
 
 - [ ] The PR request is well described and justified, including the body and the references
 - [ ] The PR title represents the desired changelog entry
+- [ ] If the change documents the new _WireMock 3 Beta_ feature, it is submitted against the [3.0.0-beta](https://github.com/wiremock/wiremock.org/tree/3.0.0-beta) branch
 - [ ] The repository's code style is followed (see the contributing guide)
 
-
+_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_


### PR DESCRIPTION
It is in the contributor guide, but needs to be more explicit

CC @tomasbjerre


