### PR TITLE
Added Dockerfile and Docker compose examples

### DIFF
--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -314,7 +314,7 @@ Variable assignment and number helpers are available:
 
 ## XPath helpers
 
-Addiionally some helpers are available for working with JSON and XML.
+Additionally some helpers are available for working with JSON and XML.
 
 When the incoming request contains XML, the `xPath` helper can be used to extract values or sub documents via an XPath 1.0 expression. For instance, given the XML
 

--- a/_docs/standalone/docker.md
+++ b/_docs/standalone/docker.md
@@ -71,3 +71,33 @@ docker run -it --rm \
   wiremock/wiremock \
     --extensions org.wiremock.webhooks.Webhooks
 ```
+
+### Building your own image
+
+Inside the container, the WireMock uses `/home/wiremock` as the root from which it reads the `mappings` and `__files` directories.
+This means you can copy your configuration from your host machine into Docker and WireMock will load the stub mappings.
+
+Wiremock utilizes a custom entrypoint script that passes all provided arguments as WireMock startup parameters. To modify the WireMock launch parameters it is recommended to override the entrypoint in your custom Docker image. 
+
+```Dockerfile
+# Sample Dockerfile
+FROM wiremock/wiremock:latest
+COPY wiremock /home/wiremock
+ENTRYPOINT ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose"]
+```
+
+### Docker Compose
+
+Configuration in compose file is similar to Dockerfile definition
+
+```YAML
+# Sample compose file
+version: "3"
+services:
+  wiremock:
+    image: "wiremock/wiremock:latest"
+    container_name: my_wiremock
+    entrypoint: ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose"]
+```
+
+


### PR DESCRIPTION
As a user I want to create an image for my specific application containing all the mappings and request/response files. I added the documentation specifying how to modify WireMock launch parameters via Dockerfile and Docker compose definition.

## References
https://wiremock-community.slack.com/archives/C03N1E6HFPY/p1690475147007479?thread_ts=1690463403.810959&cid=C03N1E6HFPY

