### PR TITLE
Wiremock 3 locations

### DIFF
--- a/_config-3.x.yml
+++ b/_config-3.x.yml
@@ -1,5 +1,6 @@
 url: "https://wiremock.org/3.x"
 destination: "./tmp/site_3x"
+wiremock_version: 3.0.0-beta-14
 wiremock_preview_site: true
 wiremock_baseline: 3.x
 wiremock_preview: true

--- a/_config.yml
+++ b/_config.yml
@@ -235,7 +235,7 @@ compress_html:
         envs: development
 
 wiremock_version: 2.35.0
-wiremock_beta_version: 3.0.0-beta-8
+wiremock_beta_version: 3.0.0-beta-14
 wiremock_baseline: 2.x
 pageEditPrefix: https://github.com/wiremock/wiremock.org/edit/main/
 

--- a/_docs/download-and-installation.md
+++ b/_docs/download-and-installation.md
@@ -31,7 +31,7 @@ conflicting versions of its dependencies. The standalone JAR is also runnable (s
 
 ```xml
 <dependency>
-    <groupId>com.github.tomakehurst</groupId>
+    <groupId>org.wiremock</groupId>
     <artifactId>wiremock-standalone</artifactId>
     <version>{{ site.wiremock_beta_version }}</version>
     <scope>test</scope>
@@ -41,10 +41,10 @@ conflicting versions of its dependencies. The standalone JAR is also runnable (s
 #### Gradle
 
 ```groovy
-testImplementation "com.github.tomakehurst:wiremock-standalone:{{ site.wiremock_beta_version }}"
+testImplementation "org.wiremock:wiremock-standalone:{{ site.wiremock_beta_version }}"
 ```
 
-### Stable
+### WireMock 2.x Stable
 
 #### Docker
 
@@ -79,5 +79,5 @@ testImplementation "com.github.tomakehurst:wiremock-jre8-standalone:{{ site.wire
 ## Direct download
 
 If you want to run WireMock as a standalone process you can
-<a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/{{ site.wiremock_version }}/wiremock-jre8-standalone-{{ site.wiremock_version }}.jar">download the standalone JAR from
+<a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/{{ site.wiremock_beta_version }}/wiremock-standalone-{{ site.wiremock_beta_version }}.jar">download the standalone JAR from
 here</a>


### PR DESCRIPTION
For #131 . It will need to be synced into the 3.x branch too

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change documents the new _WireMock 3 Beta_ feature, it is submitted against the [3.0.0-beta](https://github.com/wiremock/wiremock.org/tree/3.0.0-beta) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
