### PR TITLE
Update Artifact locations for WireMock 3.x baseline

### DIFF
--- a/_config-3.x.yml
+++ b/_config-3.x.yml
@@ -1,5 +1,6 @@
 url: "https://wiremock.org/3.x"
 destination: "./tmp/site_3x"
+wiremock_version: 3.0.0-beta-14
 wiremock_preview_site: true
 wiremock_baseline: 3.x
 wiremock_preview: true

--- a/_docs/https.md
+++ b/_docs/https.md
@@ -64,7 +64,7 @@ specify a trust store containing the certificate(s).
 
 > **note**
 >
-> Version 9.4.15.v20190215 of Jetty (used in the jre8 WireMock build) requires client certificates to contain Subject Alternative Names.
+> Jetty requires client certificates to contain Subject Alternative Names.
 > See [this script](https://github.com/tomakehurst/wiremock/blob/master/scripts/create-client-cert.sh) for an example of how to build
 > a truststore containing a valid certificate (you'll probably want to edit the client-cert.conf file before running this).
 

--- a/_docs/proxying.md
+++ b/_docs/proxying.md
@@ -182,7 +182,7 @@ WireMock.updateSettings(WireMock.getSettings().copy().proxyPassThrough(false).bu
 
 ### Browser proxying of HTTPS
 
-wiremock-jre8 allows forward proxying, stubbing & recording of HTTPS traffic.
+WireMock allows forward proxying, stubbing & recording of HTTPS traffic.
 
 This happens automatically when browser proxying is enabled.
 
@@ -232,13 +232,13 @@ This would present a substantial security risk, so by default WireMock will veri
 You can trust specific hosts as follows:
 
 ```bash
-$ java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar --enable-browser-proxying --trust-proxy-target localhost --trust-proxy-target dev.mycorp.com
+$ java -jar wiremock-standalone-{{ site.wiremock_version }}.jar --enable-browser-proxying --trust-proxy-target localhost --trust-proxy-target dev.mycorp.com
 ```
 
 or if you're not interested in security you can trust all hosts:
 
 ```bash
-$ java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar --enable-browser-proxying --trust-all-proxy-targets
+$ java -jar wiremock-standalone-{{ site.wiremock_version }}.jar --enable-browser-proxying --trust-all-proxy-targets
 ```
 
 Additional trusted public certificates can also be added to the keystore

--- a/_docs/quickstart/java-junit.md
+++ b/_docs/quickstart/java-junit.md
@@ -30,8 +30,8 @@ like [Apache HttpClient](https://hc.apache.org/httpcomponents-client-5.2.x/#).
 
 ```xml
 <dependency>
-    <groupId>com.github.tomakehurst</groupId>
-    <artifactId>wiremock-jre8</artifactId>
+    <groupId>org.wiremock</groupId>
+    <artifactId>wiremock</artifactId>
     <version>{{ site.wiremock_version }}</version>
     <scope>test</scope>
 </dependency>
@@ -46,7 +46,7 @@ like [Apache HttpClient](https://hc.apache.org/httpcomponents-client-5.2.x/#).
 ### Gradle
 
 ```groovy
-testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
+testImplementation "org.wiremock:wiremock:{{ site.wiremock_version }}"
 testImplementation "org.assertj:assertj-core:3.24.2"
 ```
 

--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -563,10 +563,6 @@ would match a request with a JSON body of:
 It's also possible to use placeholders that constrain the expected value by type or regular expression.
 See [the JsonUnit placeholders documentation](https://github.com/lukas-krecan/JsonUnit#typeplc) for the full syntax.
 
-> **note**
->
-> Placeholders are only available in the `jre8` WireMock JARs, as the JsonUnit library requires at least Java 8.
-
 ### JSON Path
 
 Deems a match if the attribute value is valid JSON and matches the [JSON Path](http://goessner.net/articles/JsonPath/) expression supplied. A JSON body will be considered to match a path expression if the expression returns either a non-null single value (string, integer etc.), or a non-empty object or array.

--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -12,10 +12,10 @@ description: The WireMock server can be run in its own process, and configured v
 The WireMock server can be run in its own process, and configured via
 the Java API, JSON over HTTP or JSON files.
 
-Once you have [downloaded the standalone JAR](https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/{{ site.wiremock_version }}/wiremock-jre8-standalone-{{ site.wiremock_version }}.jar) you can run it simply by doing this:
+Once you have [downloaded the standalone JAR](../../download) you can run it simply by doing this:
 
 ```bash
-$ java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar
+$ java -jar wiremock-standalone-{{ site.wiremock_version }}.jar
 ```
 
 ## Command line options

--- a/_docs/webhooks-and-callbacks.md
+++ b/_docs/webhooks-and-callbacks.md
@@ -50,16 +50,14 @@ on the startup command line:
 
 #### macOs / Linux:
 ```bash
-java -cp wiremock-jre8-standalone-{{ site.wiremock_version }}.jar:wiremock-webhooks-extension-{{ site.wiremock_version }}.jar \
-  com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
-  --extensions org.wiremock.webhooks.Webhooks
+java -cp wiremock-standalone-{{ site.wiremock_version }}.jar:wiremock-webhooks-extension-{{ site.wiremock_version }}.jar \
+  wiremock.Run --extensions org.wiremock.webhooks.Webhooks
 ```
 
 #### Windows:
 ```bat
-java -cp wiremock-jre8-standalone-{{ site.wiremock_version }}.jar;wiremock-webhooks-extension-{{ site.wiremock_version }}.jar \
-  com.github.tomakehurst.wiremock.standalone.WireMockServerRunner \
-  --extensions org.wiremock.webhooks.Webhooks
+java -cp wiremock-standalone-{{ site.wiremock_version }}.jar;wiremock-webhooks-extension-{{ site.wiremock_version }}.jar \
+  wiremock.Run --extensions org.wiremock.webhooks.Webhooks
 ```
 
 You can [download the webhooks extension JAR here](https://repo1.maven.org/maven2/org/wiremock/wiremock-webhooks-extension/{{ site.wiremock_version }}/wiremock-webhooks-extension-{{ site.wiremock_version }}.jar).

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -86,8 +86,8 @@
               <p class="codeTabDescription">Add the following to your project's <strong>pom.xml</strong> dependencies:</p>
 {% highlight xml %}
 <dependency>
-  <groupId>com.github.tomakehurst</groupId>
-  <artifactId>wiremock-jre8</artifactId>
+  <groupId>org.wiremock</groupId>
+  <artifactId>wiremock</artifactId>
   <version>{{ site.wiremock_version }}</version>
   <scope>test</scope>
 </dependency>
@@ -97,14 +97,14 @@
           <div class="codeSnippet" data-snippettab="gradle groovy">
             <p class="codeTabDescription">Add the following to your project's <strong>build.gradle</strong>:</p>
 {% highlight groovy %}
-testImplementation "com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}"
+testImplementation "org.wiremock:wiremock:{{ site.wiremock_version }}"
 {% endhighlight %}
             <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="{{ '/docs/junit-jupiter/' | absolute_url }}">JUnit 5+</a> or <a href="{{ '/docs/java-usage/' | absolute_url }}">plain Java</a>.</p>
           </div>
           <div class="codeSnippet" data-snippettab="gradle kotlin">
             <p class="codeTabDescription">Add the following to your project's <strong>build.gradle.kts</strong>:</p>
 {% highlight kotlin %}
-testImplementation("com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_version }}")
+testImplementation("org.wiremock:wiremock:{{ site.wiremock_version }}")
 {% endhighlight %}
             <p class="codeTabDescription" style="margin-top:2rem;">Then follow the next steps for <a href="{{ '/docs/junit-jupiter/' | absolute_url }}">JUnit 5+</a> or <a href="{{ 'docs/java-usage/' | absolute_url }}">plain Java</a>.</p>
           </div>
@@ -112,16 +112,16 @@ testImplementation("com.github.tomakehurst:wiremock-jre8:{{ site.wiremock_versio
             <p class="codeTabDescription">Add the following to your project’s <strong>build.sbt</strong>:</p>
 {% highlight scala %}
 libraryDependencies +=
-  "com.github.tomakehurst" % "wiremock-jre8" % "{{ site.wiremock_version }}" % Test
+  "org.wiremock" % "wiremock" % "{{ site.wiremock_version }}" % Test
 {% endhighlight %}
           </div>
           <div class="codeSnippet" data-snippettab="standalone">
             <p class="codeTabDescription">
-              Download the <a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/{{ site.wiremock_version }}/wiremock-jre8-standalone-{{ site.wiremock_version }}.jar">latest standalone JAR</a>
+              Download the <a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/{{ site.wiremock_version }}/wiremock-standalone-{{ site.wiremock_version }}.jar">latest standalone JAR</a>
               then run the following in a terminal:
             </p>
 {% highlight bash %}
-java -jar wiremock-jre8-standalone-{{ site.wiremock_version }}.jar
+java -jar wiremock-standalone-{{ site.wiremock_version }}.jar
 {% endhighlight %}
             <p class="codeTabDescription" style="margin-top:2rem;">Learn more in the <a href="{{ 'docs/running-standalone/' | absolute_url }}">running standalone guide.</a></p>
           </div>


### PR DESCRIPTION
Updates the 3.x baseline with the new artifact locations. Also cleans up some obsolete references while there For #132 and #131 

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change documents the new _WireMock 3 Beta_ feature, it is submitted against the [3.0.0-beta](https://github.com/wiremock/wiremock.org/tree/3.0.0-beta) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
