### PR TITLE
fix: bump latest `wiremock_beta_version` to `3.0.0-beta-15`

### DIFF
--- a/_config-3.x.yml
+++ b/_config-3.x.yml
@@ -1,6 +1,6 @@
 url: "https://wiremock.org/3.x"
 destination: "./tmp/site_3x"
-wiremock_version: 3.0.0-beta-14
+wiremock_version: 3.0.0-beta-15
 wiremock_preview_site: true
 wiremock_baseline: 3.x
 wiremock_preview: true

--- a/_config.yml
+++ b/_config.yml
@@ -49,7 +49,7 @@ social:
       - https://twitter.com/wiremockorg
       - https://fosstodon.org/@wiremock
       - https://www.youtube.com/@WireMockTV
-    
+
 # Analytics
 analytics:
     google:
@@ -235,7 +235,7 @@ compress_html:
         envs: development
 
 wiremock_version: 2.35.0
-wiremock_beta_version: 3.0.0-beta-14
+wiremock_beta_version: 3.0.0-beta-15
 wiremock_baseline: 2.x
 pageEditPrefix: https://github.com/wiremock/wiremock.org/edit/main/
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- See the snapshot for the latest wiremock beta release.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change documents the new _WireMock 3 Beta_ feature, it is submitted against the [3.0.0-beta](https://github.com/wiremock/wiremock.org/tree/3.0.0-beta) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_

![image](https://github.com/wiremock/wiremock.org/assets/1580956/01e0c071-e4a1-4949-9492-98307399d89c)
