### PR TITLE
Deploy the 3.x links too, same as the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
           bundle exec jekyll build --config '../../_config.yml,../../_config-2.x.yml' --baseurl "${{ steps.pages.outputs.base_path }}/2.x"
         env:
           JEKYLL_ENV: development
+# TODO: Add 3.x build? It is just a config file tweak, so maybe better to not slowdown for now
+
+
 # TODO: Uncomment when cleaned up (if ever)
 #      - name: Validate HTML and links
 #        uses: anishathalye/proof-html@v2

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -55,14 +55,19 @@ jobs:
           bundle exec jekyll build --config '../../_config.yml,../../_config-2.x.yml' --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
-      - name: Deploy 2.x to the website
-        # Outputs to the './_site' directory by default
+      - name: Build 3.x with Jekyll
+        # We use the same as the root build, but with additional config
+        run: |
+          bundle exec jekyll build --config '_config.yml,_config-3.x.yml' --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+      - name: Deploy version branches to the website
         run: |
           ruby .scripts/merge-sitemaps.rb
           mkdir _site/2.x
           cp -R .submodules/wiremock.org-2.x/tmp/site_2x/* _site/2.x/
-        env:
-          JEKYLL_ENV: production
+          mkdir _site/3.x
+          cp -R tmp/site_3x/* _site/3.x/
 # TODO: Uncomment when cleaned up (if ever)
 #      - name: Validate HTML and links
 #        uses: anishathalye/proof-html@v2

--- a/.scripts/merge-sitemaps.rb
+++ b/.scripts/merge-sitemaps.rb
@@ -1,21 +1,27 @@
 # Merges sitemaps, to be called from the root directory
-header, footer, content1, content2 = []
+header, footer, content_main, content_2x, content_3x = []
 
 File.open( "_site/sitemap.xml", 'r' ) do |f1|
-    content1 = (IO.readlines f1)
-    header = content1.slice!( 0..11 )
-    footer = [ content1.slice!( -1 ) ]
+    content_main = (IO.readlines f1)
+    header = content_main.slice!( 0..11 )
+    footer = [ content_main.slice!( -1 ) ]
 end
 
 File.open( ".submodules/wiremock.org-2.x/tmp/site_2x/sitemap.xml", 'r' ) do |f2|
-    content2 = (IO.readlines f2)
-    content2.slice!( 0..11 )
-    content2.slice!( -1 ) 
+    content_2x = (IO.readlines f2)
+    content_2x.slice!( 0..11 )
+    content_2x.slice!( -1 ) 
 end
 
-File.open( "_site/sitemap.xml", 'w' ) do |f3|
-    f3.write ( header + content1 + content2 + footer ).join()
+File.open( "./tmp/site_3x/sitemap.xml", 'r' ) do |f3|
+    content_3x = (IO.readlines f3)
+    content_3x.slice!( 0..11 )
+    content_3x.slice!( -1 ) 
+end
+
+File.open( "_site/sitemap.xml", 'w' ) do |f4|
+    f4.write ( header + content_main + content_2x + content_3x + footer ).join()
 end
 
 
-puts "Merged main and 3.x sitemaps"
+puts "Merged main and version sitemaps"

--- a/_config-3.x.yml
+++ b/_config-3.x.yml
@@ -1,0 +1,2 @@
+url: "https://wiremock.org/3.x"
+destination: "./tmp/site_3x"


### PR DESCRIPTION
For  #147 . It does not seem Jekyll supports folder redfirects hence a hack

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
