### PR TITLE
Fix navigation for docs and masthead

### DIFF
--- a/_data/baselines.yml
+++ b/_data/baselines.yml
@@ -1,11 +1,11 @@
 # Current GA Version of WireMock
 current:
-  id: 2.x
+  id: 3.x
   absoluteUrl: https://wiremock.org
 # List of preview versions
 preview: 
-  id: 3.x
-  absoluteUrl: https://wiremock.org/3.x
-  scopeUrl: https://github.com/orgs/wiremock/projects/5
 # List of old versions documentation for which is served on the website
 archive:
+  id: 2.x
+  absoluteUrl: https://wiremock.org/2.x
+  branch: 2.x

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -8,7 +8,7 @@ main:
       subnavLinks:
         - name: "WireMock"
           subnavLink: "/docs/"
-        - name: "WireMock 3.x (Preview)"
+        - name: "WireMock 3.x Docs"
           subnavLink: "/3.x/docs/"
           wiremock_baseline: 3.x
         - name: "Mock API Templates"
@@ -17,6 +17,9 @@ main:
           subnavLink: "https://docs.wiremock.io/getting-started/?utm_source=wiremock.org&utm_medium=masthead_doc-links&utm_campaign=2022_baseline"
         - name: "External Resources"
           subnavLink: "/external-resources"
+        - name: "WireMock 2.x (Archive)"
+          subnavLink: "/2.x/docs/"
+          wiremock_baseline: 2.x
 
     - title: "Need Help?"
       link: "/support"

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -50,11 +50,13 @@ layout: default
       </header>
 
       {% if site.wiremock_baseline == site.data.baselines.current.id %} 
-      <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
-        This document is for the WireMock {{ site.data.baselines.current.id }} baseline.
-        See the documentation for WireMock {{ site.data.baselines.preview.id }} preview 
-        <a href="{{  page.url | prepend: site.data.baselines.preview.absoluteUrl }}">here</a>
-      </div>
+        {% if site.data.baselines.preview.id %}
+        <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">
+          This document is for the WireMock {{ site.data.baselines.current.id }} baseline.
+          See the documentation for WireMock {{ site.data.baselines.preview.id }} preview 
+          <a href="{{  page.url | prepend: site.data.baselines.preview.absoluteUrl }}">here</a>
+        </div>
+        {% endif %}
       {% else %}
         {% if site.wiremock_baseline == site.data.baselines.preview.id %} 
         <div style="background-color: #f2f2f2;border: #c8c8c8 1px solid;padding: 8px;margin-bottom:32px;">


### PR DESCRIPTION
Applies the rendering patch for 2.x branch. For #147 
 
## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
