### PR TITLE
Fix Maven bogus version in downloads

### DIFF
--- a/_docs/download-and-installation.md
+++ b/_docs/download-and-installation.md
@@ -40,7 +40,7 @@ docker run -it --rm -p 8080:8080 --name wiremock \
 <dependency>
     <groupId>org.wiremock</groupId>
     <artifactId>wiremock-standalone</artifactId>
-    <version>{{ site.wiremock_beta_version }}</version>
+    <version>{{ site.wiremock_version }}</version>
     <scope>test</scope>
 </dependency>
 ```
@@ -48,7 +48,7 @@ docker run -it --rm -p 8080:8080 --name wiremock \
 ### Gradle
 
 ```groovy
-testImplementation "org.wiremock:wiremock-standalone:{{ site.wiremock_beta_version }}"
+testImplementation "org.wiremock:wiremock-standalone:{{ site.wiremock_version }}"
 ```
 
 Learn more in the [Docker guide](../docker).
@@ -56,5 +56,5 @@ Learn more in the [Docker guide](../docker).
 ### Direct download
 
 If you want to run WireMock as a standalone process you can
-<a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/{{ site.wiremock_beta_version }}/wiremock-standalone-{{ site.wiremock_beta_version }}.jar">download the standalone JAR from
+<a id="wiremock-standalone-download" href="https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/{{ site.wiremock_version }}/wiremock-standalone-{{ site.wiremock_version }}.jar">download the standalone JAR from
 here</a>


### PR DESCRIPTION
Regression after #147 

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
