### PR TITLE
Fix redirects for Downloads

### DIFF
--- a/_docs/download-and-installation.md
+++ b/_docs/download-and-installation.md
@@ -6,6 +6,13 @@ toc_rank: 13
 description: >
     WireMock is available as a standalone service (for Docker of Java), Java library
     and integrations for modern languages and technology stacks.
+redirect_from: 
+    - "/download.html"
+    - "/download/"
+    - "/downloads.html"
+    - "/downloads/"
+    - "/docs/download.html"
+    - "/docs/download/"
 ---
 
 


### PR DESCRIPTION
Looks like there was a bogus merge. Fixes #159 , at least the last issue reported there

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
