### PR TITLE
Add support for rendering code tabs

### DIFF
--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -8,21 +8,26 @@ description: WireMock supports matching of requests to stubs and verification qu
 
 WireMock enables flexible definition of a [mock API](/) by supporting rich matching of incoming requests. Stub matching and verification queries can use the following request attributes:
 
--   URL
--   HTTP Method
--   Query parameters
--   Form parameters
--   Headers
--   Basic authentication (a special case of header matching)
--   Cookies
--   Request body
--   Multipart/form-data
+- URL
+- HTTP Method
+- Query parameters
+- Form parameters
+- Headers
+- Basic authentication (a special case of header matching)
+- Cookies
+- Request body
+- Multipart/form-data
 
 Here's an example showing all attributes being matched using WireMock's in-built match operators. It is also possible to write [custom matching logic](../extending-wiremock#custom-request-matchers) if
 you need more precise control:
 
 ## Request with XML Body
-Java:
+
+Code:
+
+{% codetabs %}
+
+{% codetab Java %}
 
 ```java
 stubFor(any(urlPathEqualTo("/everything"))
@@ -41,7 +46,31 @@ stubFor(any(urlPathEqualTo("/everything"))
   .willReturn(aResponse()));
 ```
 
-JSON:
+{% endcodetab %}
+
+{% codetab Python %}
+
+```python
+print("Hello, world!")
+```
+
+{% endcodetab %}
+
+{% codetab Go %}
+
+```golang
+fmt.Println("Hello, world!")
+```
+
+{% endcodetab %}
+
+{% endcodetabs %}
+
+Configuration file:
+
+{% codetabs %}
+
+{% codetab JSON %}
 
 ```json
 {
@@ -100,6 +129,14 @@ JSON:
 }
 ```
 
+{% endcodetab %}
+
+{% codetab YAML %}
+
+{% endcodetab %}
+
+{% endcodetabs %}
+
 ## Request with Form Parameters
 
 ```java
@@ -125,7 +162,6 @@ stubFor(post(urlPathEqualTo("/mock"))
     }
 }
 ```
-
 
 The following sections describe each type of matching strategy in detail.
 
@@ -664,7 +700,7 @@ JSON:
 
 Request body example:
 
-```
+```json
 // matching
 { "things": { "name": "RequiredThing" } }
 { "things": [ { "name": "Required" }, { "name": "Wiremock" } ] }
@@ -701,7 +737,7 @@ JSON:
 
 Request body example:
 
-```
+```json
 // matching
 { "things": [ { "name": "RequiredThing" }, { "name": "Wiremock" } ] }
 // not matching
@@ -1340,14 +1376,14 @@ JSON:
 <div id="all-truncations"></div>
 The full list of available truncations is:
 
--   `first minute of hour`
--   `first hour of day`
--   `first day of month`
--   `first day of next month`
--   `last day of month`
--   `first day of year`
--   `first day of next year`
--   `last day of year`
+- `first minute of hour`
+- `first hour of day`
+- `first day of month`
+- `first day of next month`
+- `last day of month`
+- `first day of year`
+- `first day of next year`
+- `last day of year`
 
 ## Logical AND and OR
 
@@ -1487,7 +1523,6 @@ This would match the following JSON request body:
 }
 ```
 
-
 ### Matching Header/Query parameter containing multiple values
 
 You can match multiple values of a query parameter or header with below provided matchers.
@@ -1501,7 +1536,7 @@ stubFor(get(urlPathEqualTo("/things"))
     .willReturn(ok()));
 ```
 
-```json 
+```json
 {
   "mapping": {
     "request" : {
@@ -1607,7 +1642,6 @@ stubFor(get(urlPathEqualTo("/things"))
 }
 ```
 
-
 ```java
 //values of id must conform to the match expressions
 stubFor(get(urlPathEqualTo("/things"))
@@ -1617,6 +1651,7 @@ stubFor(get(urlPathEqualTo("/things"))
     notContaining("3")
     )).willReturn(ok()));
 ```
+
 ```json
 {
   "mapping": {

--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -25,10 +25,6 @@ you need more precise control:
 
 Code:
 
-{% codetabs %}
-
-{% codetab Java %}
-
 ```java
 stubFor(any(urlPathEqualTo("/everything"))
   .withHeader("Accept", containing("xml"))
@@ -46,31 +42,7 @@ stubFor(any(urlPathEqualTo("/everything"))
   .willReturn(aResponse()));
 ```
 
-{% endcodetab %}
-
-{% codetab Python %}
-
-```python
-print("Hello, world!")
-```
-
-{% endcodetab %}
-
-{% codetab Go %}
-
-```golang
-fmt.Println("Hello, world!")
-```
-
-{% endcodetab %}
-
-{% endcodetabs %}
-
 Configuration file:
-
-{% codetabs %}
-
-{% codetab JSON %}
 
 ```json
 {
@@ -128,14 +100,6 @@ Configuration file:
     }
 }
 ```
-
-{% endcodetab %}
-
-{% codetab YAML %}
-
-{% endcodetab %}
-
-{% endcodetabs %}
 
 ## Request with Form Parameters
 

--- a/_docs/stubbing.md
+++ b/_docs/stubbing.md
@@ -12,10 +12,43 @@ responses for requests matching criteria. These are described in detail in [Requ
 
 ## Basic stubbing
 
-The following code will configure a response with a status of 200 to be
-returned when the relative URL exactly matches `/some/thing` (including
-query parameters). The body of the response will be "Hello world!" and a
+You can configure stubs using JSON configuration files or code:
+
+1. Via a `.json` file under the `mappings` directory
+2. Via a POST request to
+`http://<host>:<port>/__admin/mappings` with the JSON as a body
+3. From code using one of the SDKs
+
+**Example.**
+To configure a response with a status of 200 to be returned
+when the relative URL exactly matches `/some/thing` (including query parameters).
+The body of the response will be "Hello world!" and a
 `Content-Type` header will be sent with a value of `text-plain`.
+
+{% codetabs %}
+
+{% codetab JSON %}
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "url": "/some/thing"
+  },
+
+  "response": {
+    "status": 200,
+    "body": "Hello, world!",
+    "headers": {
+        "Content-Type": "text/plain"
+    }
+  }
+}
+```
+
+{% endcodetab %}
+
+{% codetab Java %}
 
 ```java
 @Test
@@ -30,31 +63,38 @@ public void exactUrlOnly() {
 }
 ```
 
-> **note**
->
-> If you'd prefer to use slightly more BDDish language in your tests you
-> can replace `stubFor` with `givenThat`.
+{% endcodetab %}
 
-To create the stub described above via the JSON API, the following
-document can either be posted to
-`http://<host>:<port>/__admin/mappings` or placed in a file with a
-`.json` extension under the `mappings` directory:
+{% codetab Python %}
 
-```json
-{
-    "request": {
-        "method": "GET",
-        "url": "/some/thing"
-    },
-    "response": {
-        "status": 200,
-        "body": "Hello world!",
-        "headers": {
-            "Content-Type": "text/plain"
-        }
-    }
-}
+```python
+Mappings.create_mapping(
+    Mapping(
+        request=MappingRequest(method=HttpMethods.GET, url="/some/thing"),
+        response=MappingResponse(status=200, body="Hello, world!", headers=("Content-Type", "text/plain")),
+    )
+)
 ```
+
+{% endcodetab %}
+
+{% codetab Golang %}
+
+```go
+wiremockClient.StubFor(wiremock.Get(wiremock.URLPathEqualTo("/some/thing")).
+        WillReturnResponse(
+            wiremock.NewResponse().
+                WithStatus(http.StatusOK).
+                WithBody("Hello, world!").
+                WithHeader("Content-Type", "text/plain")))
+```
+
+{% endcodetab %}
+
+{% endcodetabs %}
+
+In Java, if you'd prefer to use slightly more BDDish language in your tests,
+you can replace `stubFor` with `givenThat`.
 
 ### Java Shortcuts
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -76,7 +76,10 @@ layout: default
   <!-- For rendering code tabs without UIKit in the original Code Tabs plugin, also with grouping  -->
   <script>
     document.addEventListener("DOMContentLoaded", function(){
-      document.getElementById("default").click();
+      var defaultTabs = document.querySelectorAll("#codeblock-default-selection")
+      for (i = 0; i < defaultTabs.length; i++) {
+        defaultTabs[i].click();
+      }
     });
 
     function showTab(evt, tabId) {

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -38,13 +38,20 @@ layout: default
     }
 
     .tab button {
-      background-color: inherit;
-      float: left;
+      background-color: inherit; 
       border: none;
       outline: none;
       cursor: pointer;
       padding: 14px 16px;
       transition: 0.3s;
+    }
+
+    .codeblock-option-selector {
+      float: left;
+    }
+
+    .codeblock-copybutton {
+      float: right;
     }
 
     .tab button:hover {
@@ -103,6 +110,20 @@ layout: default
       // Show the current tab, and add an "active" class to the button that opened the tab
       codeblock.querySelector("#"+tabId).style.display = "block";
       evt.currentTarget.className += " active";
+    }
+
+    function copyCodeTabToClipboard(evt) {
+      var range = document.createRange();
+      var currentTab = evt.currentTarget
+      var activeTab = currentTab.parentElement.querySelector("button.active")
+      var tabId = activeTab.textContent
+
+      var codeblock = currentTab.parentElement.parentElement.querySelector("#"+tabId)
+      range.selectNode(codeblock);
+      window.getSelection().removeAllRanges(); // clear current selection
+      window.getSelection().addRange(range); // to select text
+      document.execCommand("copy");
+      window.getSelection().removeAllRanges();// to deselect
     }
   </script>
   

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -29,7 +29,79 @@ layout: default
       visibility: visible;
     }
 
+
+    /* Code tabs inspired by https://github.com/clustergarage/jekyll-code-tabs/pull/5 */
+    .tab {
+      overflow: hidden;
+      border: 1px solid #ccc;
+      background-color: #f1f1f1;
+    }
+
+    .tab button {
+      background-color: inherit;
+      float: left;
+      border: none;
+      outline: none;
+      cursor: pointer;
+      padding: 14px 16px;
+      transition: 0.3s;
+    }
+
+    .tab button:hover {
+      background-color: #ddd;
+    }
+
+    .tab button.active {
+      background-color: #ccc;
+    }
+
+    .tabcontent {
+      display: none;
+      padding: 6px 12px;
+      border: 1px solid #ccc;
+      border-top: none;
+    }
+
+    .tabcontent {
+      animation: fadeEffect 0.5s; /* Fading effect takes 1 second */
+    }
+
+    @keyframes fadeEffect {
+      from {opacity: 0.5;}
+      to {opacity: 1;}
+    }
+
   </style>
+
+  <!-- For rendering code tabs without UIKit in the original Code Tabs plugin, also with grouping  -->
+  <script>
+    document.addEventListener("DOMContentLoaded", function(){
+      document.getElementById("default").click();
+    });
+
+    function showTab(evt, tabId) {
+      // Declare all variables
+      var i, tabcontent, tablinks;
+      var currentTab = evt.currentTarget
+      var codeblock = currentTab.parentElement.parentElement
+
+      // Get all elements with class="tabcontent" and hide them
+      tabcontent = codeblock.getElementsByClassName("tabcontent");
+      for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+      }
+
+      // Get all elements with class="tablinks" and remove the class "active"
+      tablinks = codeblock.getElementsByClassName("tablinks");
+      for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].className = tablinks[i].className.replace(" active", "");
+      }
+
+      // Show the current tab, and add an "active" class to the button that opened the tab
+      codeblock.querySelector("#"+tabId).style.display = "block";
+      evt.currentTarget.className += " active";
+    }
+  </script>
   
 
   <article class="page" itemscope itemtype="http://schema.org/CreativeWork">

--- a/_plugins/jekyll-code-tabs.rb
+++ b/_plugins/jekyll-code-tabs.rb
@@ -1,0 +1,1 @@
+require_relative "../lib/jekyll-code-tabs"

--- a/lib/jekyll-code-tabs.rb
+++ b/lib/jekyll-code-tabs.rb
@@ -1,0 +1,58 @@
+require "erb"
+require 'securerandom'
+require_relative "jekyll-code-tabs/version"
+
+module Jekyll
+  module CodeTabs
+    class CodeTabsBlock < Liquid::Block
+      def render(context)
+        environment = context.environments.first
+        environment['codetabs'] = {} # reset each time
+        super
+
+        uuid = SecureRandom.uuid
+				template = ERB.new <<-EOF
+<!-- Tab links -->
+<div class=codeblock>
+    <div class="tab">
+        <% environment['codetabs'].each_with_index do |(key, _), index| %> 
+        <button class="tablinks" id="<%= index == 0 ? 'default' : '' %>" onclick="showTab(event, '<%= key %>')"><%= key %></button>
+        <% end %>
+    </div>
+                    
+    <!-- Tab content -->
+    <% environment['codetabs'].each do |key, value| %>
+    <div id="<%= key %>" class="tabcontent">
+        <%= value %>
+    </div>
+    <% end %>
+</div>
+EOF
+				template.result(binding)
+      end
+    end
+
+    class CodeTabBlock < Liquid::Block
+      alias_method :render_block, :render
+
+      def initialize(tag_name, markup, tokens)
+        super
+        if markup == ""
+          raise SyntaxError.new("No toggle name given in #{tag_name} tag")
+        end
+        @toggle = markup.strip
+      end
+
+      def render(context)
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        environment = context.environments.first
+        environment['codetabs'] ||= {}
+        environment['codetabs'][@toggle] = converter.convert(render_block(context))
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("codetab", Jekyll::CodeTabs::CodeTabBlock)
+Liquid::Template.register_tag("codetabs", Jekyll::CodeTabs::CodeTabsBlock)

--- a/lib/jekyll-code-tabs.rb
+++ b/lib/jekyll-code-tabs.rb
@@ -16,7 +16,7 @@ module Jekyll
 <div class=codeblock>
     <div class="tab">
         <% environment['codetabs'].each_with_index do |(key, _), index| %> 
-        <button class="tablinks" id="<%= index == 0 ? 'default' : '' %>" onclick="showTab(event, '<%= key %>')"><%= key %></button>
+        <button class="tablinks" id="<%= index == 0 ? 'codeblock-default-selection' : '' %>" onclick="showTab(event, '<%= key %>')"><%= key %></button>
         <% end %>
     </div>
                     

--- a/lib/jekyll-code-tabs.rb
+++ b/lib/jekyll-code-tabs.rb
@@ -16,8 +16,9 @@ module Jekyll
 <div class=codeblock>
     <div class="tab">
         <% environment['codetabs'].each_with_index do |(key, _), index| %> 
-        <button class="tablinks" id="<%= index == 0 ? 'codeblock-default-selection' : '' %>" onclick="showTab(event, '<%= key %>')"><%= key %></button>
+        <button class="tablinks codeblock-option-selector" id="<%= index == 0 ? 'codeblock-default-selection' : '' %>" onclick="showTab(event, '<%= key %>')"><%= key %></button>
         <% end %>
+        <button class="codeblock-copybutton" onclick="copyCodeTabToClipboard(event)">Copy</button>
     </div>
                     
     <!-- Tab content -->

--- a/lib/jekyll-code-tabs/version.rb
+++ b/lib/jekyll-code-tabs/version.rb
@@ -1,0 +1,5 @@
+module Jekyll
+    module CodeTabs
+        VERSION = "1.2.0-patched".freeze
+    end
+end


### PR DESCRIPTION
Adds rendering of code tabs with a copy button

Example:

![image](https://github.com/wiremock/wiremock.org/assets/3000480/4e75d642-f3b4-48ef-a7c1-e0adf2a2e92f)


## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
