### PR TITLE
Code Tabs: Move inline JS to the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,3 +14,4 @@
 <script src="{{ '/assets/js/sidebar-docs.js' | absolute_url }}"></script>
 <script src="{{ '/assets/js/tracking-events.js' | absolute_url }}"></script>
 <script src="{{ '/assets/js/faq.js' | absolute_url }}"></script>
+<script src="{{ '/assets/js/jekyll-code-tabs.js' | absolute_url }}"></script>

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -80,54 +80,6 @@ layout: default
 
   </style>
 
-  <!-- For rendering code tabs without UIKit in the original Code Tabs plugin, also with grouping  -->
-  <script>
-    document.addEventListener("DOMContentLoaded", function(){
-      var defaultTabs = document.querySelectorAll("#codeblock-default-selection")
-      for (i = 0; i < defaultTabs.length; i++) {
-        defaultTabs[i].click();
-      }
-    });
-
-    function showTab(evt, tabId) {
-      // Declare all variables
-      var i, tabcontent, tablinks;
-      var currentTab = evt.currentTarget
-      var codeblock = currentTab.parentElement.parentElement
-
-      // Get all elements with class="tabcontent" and hide them
-      tabcontent = codeblock.getElementsByClassName("tabcontent");
-      for (i = 0; i < tabcontent.length; i++) {
-        tabcontent[i].style.display = "none";
-      }
-
-      // Get all elements with class="tablinks" and remove the class "active"
-      tablinks = codeblock.getElementsByClassName("tablinks");
-      for (i = 0; i < tablinks.length; i++) {
-        tablinks[i].className = tablinks[i].className.replace(" active", "");
-      }
-
-      // Show the current tab, and add an "active" class to the button that opened the tab
-      codeblock.querySelector("#"+tabId).style.display = "block";
-      evt.currentTarget.className += " active";
-    }
-
-    function copyCodeTabToClipboard(evt) {
-      var range = document.createRange();
-      var currentTab = evt.currentTarget
-      var activeTab = currentTab.parentElement.querySelector("button.active")
-      var tabId = activeTab.textContent
-
-      var codeblock = currentTab.parentElement.parentElement.querySelector("#"+tabId)
-      range.selectNode(codeblock);
-      window.getSelection().removeAllRanges(); // clear current selection
-      window.getSelection().addRange(range); // to select text
-      document.execCommand("copy");
-      window.getSelection().removeAllRanges();// to deselect
-    }
-  </script>
-  
-
   <article class="page" itemscope itemtype="http://schema.org/CreativeWork">
     {% if page.seo_title %}<meta itemprop="headline" content="{{ page.seo_title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}

--- a/assets/js/jekyll-code-tabs.js
+++ b/assets/js/jekyll-code-tabs.js
@@ -1,0 +1,44 @@
+// For rendering code tabs without UIKit in the original Code Tabs plugin, also with grouping
+document.addEventListener("DOMContentLoaded", function() {
+    var defaultTabs = document.querySelectorAll("#codeblock-default-selection")
+    for (i = 0; i < defaultTabs.length; i++) {
+    defaultTabs[i].click();
+    }
+});
+
+function showTab(evt, tabId) {
+    // Declare all variables
+    var i, tabcontent, tablinks;
+    var currentTab = evt.currentTarget
+    var codeblock = currentTab.parentElement.parentElement
+
+    // Get all elements with class="tabcontent" and hide them
+    tabcontent = codeblock.getElementsByClassName("tabcontent");
+    for (i = 0; i < tabcontent.length; i++) {
+    tabcontent[i].style.display = "none";
+    }
+
+    // Get all elements with class="tablinks" and remove the class "active"
+    tablinks = codeblock.getElementsByClassName("tablinks");
+    for (i = 0; i < tablinks.length; i++) {
+    tablinks[i].className = tablinks[i].className.replace(" active", "");
+    }
+
+    // Show the current tab, and add an "active" class to the button that opened the tab
+    codeblock.querySelector("#"+tabId).style.display = "block";
+    evt.currentTarget.className += " active";
+}
+
+function copyCodeTabToClipboard(evt) {
+    var range = document.createRange();
+    var currentTab = evt.currentTarget
+    var activeTab = currentTab.parentElement.querySelector("button.active")
+    var tabId = activeTab.textContent
+
+    var codeblock = currentTab.parentElement.parentElement.querySelector("#"+tabId)
+    range.selectNode(codeblock);
+    window.getSelection().removeAllRanges(); // clear current selection
+    window.getSelection().addRange(range); // to select text
+    document.execCommand("copy");
+    window.getSelection().removeAllRanges();// to deselect
+}


### PR DESCRIPTION
The production deploy does not work with embedded JavaScript, hence refactoring

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
