### PR TITLE
fix: make css grid container responsive in docs page

### DIFF
--- a/_docs/index.html
+++ b/_docs/index.html
@@ -17,7 +17,7 @@ description: >
         margin-right: auto;
         max-width: 61rem;
         gap: 1rem;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(auto-fill, 15rem);
         vertical-align: middle;
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

in the docs page, each subsection is styled as a `card` item within a css grid layout

before the change, the grid items always occupied 3 columns and it overflowed the page article div:
![grid-container-overflow](https://github.com/wiremock/wiremock.org/assets/19340445/cba121bb-8bc9-401e-9d59-92da1d5f2d08)

edited the css property `grid-template-columns` to make the layout responsive:
![css-grid-fix](https://github.com/wiremock/wiremock.org/assets/19340445/d6ddba13-138a-4e1c-8f52-8364cacd217c)

## References

Fixes https://github.com/wiremock/wiremock.org/issues/95

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
