### PR TITLE
Fix example target URL in recording docs

### DIFF
--- a/_docs/record-playback.md
+++ b/_docs/record-playback.md
@@ -24,7 +24,7 @@ Once that's running visit the recorder UI page at [http://localhost:8080/\_\_adm
 
 ![Recorder UI]({{ '/images/recorder-screenshot.png' | absolute_url }})
 
-Enter the URL you wish to record from in the target URL field and click the Record button. You can use `http://examples.wiremockapi.cloud/` to try it out.
+Enter the URL you wish to record from in the target URL field and click the Record button. You can use `http://examples.wiremockapi.cloud` to try it out.
 
 Now you need to make a request through WireMock to the target API so that it can be recorded. If you're using the example URL, you can generate a request using curl:
 


### PR DESCRIPTION
Remove the trailing slash from the suggested example target URL because it causes `java.lang.IllegalArgumentException: URI path begins with multiple slashes` when the curl request is made later in the example.

```bash
curl http://localhost:8080/recordables/123
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=ISO-8859-1"/>
<title>Error 500 java.lang.IllegalArgumentException: URI path begins with multiple slashes</title>
</head>
<body><h2>HTTP ERROR 500 java.lang.IllegalArgumentException: URI path begins with multiple slashes</h2>
<table>
<tr><th>URI:</th><td>/recordables/123</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>java.lang.IllegalArgumentException: URI path begins with multiple slashes</td></tr>
<tr><th>SERVLET:</th><td>com.github.tomakehurst.wiremock.servlet.WireMockHandlerDispatchingServlet-58594a11</td></tr>
<tr><th>CAUSED BY:</th><td>java.lang.IllegalArgumentException: URI path begins with multiple slashes</td></tr>
</table>
```
Removing the trailing slash in the suggested target URL fixes the example.

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
