### PR TITLE
Add support for wide-screen docs landings and spec visualization

### DIFF
--- a/_docs/index.html
+++ b/_docs/index.html
@@ -5,6 +5,7 @@ meta_title: "WireMock User Documentation | WireMock"
 crumbtitle: "Documentation"
 toc_rank: 1001
 permalink: /docs/
+docs-wide: true
 description: > 
     All of WireMock’s features are accessible via its REST (JSON) interface and its Java API.
     Additionally, stubs can be configured via JSON files. Read the full doc here.
@@ -15,7 +16,7 @@ description: >
         display: grid;
         margin-left: auto;
         margin-right: auto;
-        max-width: 61rem;
+        max-width: 160rem;
         gap: 1rem;
         grid-template-columns: repeat(auto-fill, 15rem);
         vertical-align: middle;

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -80,7 +80,7 @@ layout: default
 
   </style>
 
-  <article class="page" itemscope itemtype="http://schema.org/CreativeWork">
+  <article class="{% if page.docs-wide %}page-wide{% else %}page{% endif %}" itemscope itemtype="http://schema.org/CreativeWork">
     {% if page.seo_title %}<meta itemprop="headline" content="{{ page.seo_title | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.excerpt %}<meta itemprop="description" content="{{ page.excerpt | markdownify | strip_html | strip_newlines | escape_once }}">{% endif %}
     {% if page.date %}<meta itemprop="datePublished" content="{{ page.date | date: "%B %d, %Y" }}">{% endif %}

--- a/_sass/_page.scss
+++ b/_sass/_page.scss
@@ -14,6 +14,10 @@
     @include breakpoint($x-large) {
         max-width: $x-large;
     }
+
+    @include breakpoint($x2-large) {
+        max-width: $x2-large;
+    }
 }
 
 .custom-doc-wrapper {
@@ -36,6 +40,11 @@
             @include full();
         }
     }
+}
+
+.page-wide {
+    @extend .page;
+    @include suffix(0 of 12);
 }
 
 .page__title {
@@ -141,6 +150,10 @@
 
             @include breakpoint($x-large) {
                 max-width: $x-large;
+            }
+
+            @include breakpoint($x2-large) {
+                max-width: $x2-large;
             }
         }
 

--- a/_sass/_splash.scss
+++ b/_sass/_splash.scss
@@ -11,10 +11,21 @@
         border: none !important;
     }
 
-    width: 950px;
+    @include breakpoint($large) {
+        padding: 50px 0;
+    }
+
+    @include breakpoint($x-large) {
+        width: $x-large;
+    }
+
+    @include breakpoint($x2-large) {
+        width: $x2-large;
+    }
+
     margin-left: auto;
     margin-right: auto;
-    padding: 50px 0;
+    
 
     h1 {
         font-family: "Ubuntu";

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -121,6 +121,7 @@ $medium: 768px;
 $medium-wide: 900px;
 $large: 1024px;
 $x-large: 1280px;
+$x2-large: 1920px;
 
 /*
    Grid


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

![image](https://github.com/wiremock/wiremock.org/assets/3000480/f3f1a58f-4bf1-4da5-ab37-662b48d672f8)

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
