### PR TITLE
Add WireMock Spring Boot to the Solutions page

### DIFF
--- a/_docs/solutions/spring-boot.md
+++ b/_docs/solutions/spring-boot.md
@@ -1,12 +1,55 @@
 ---
 layout: solution
-title: "Using with Spring Boot"
+title: "Using WireMock with Spring Boot"
 meta_title: Running WireMock with Spring Boot | WireMock
 toc_rank: 116
 description: The team behind Spring Cloud Contract have created a library to support running WireMock using the “ambient” HTTP server
-redirect_from: "/docs/spring-boot.html"
+redirect_from:
+- "/docs/spring-boot.html"
 logo: /images/logos/technology/spring.svg
 ---
+
+## WireMock Spring Boot
+
+[WireMock Spring Boot](https://github.com/maciejwalkowiak/wiremock-spring-boot) 
+simplifies testing HTTP clients in Spring Boot & Junit 5 based integration tests.
+It includes fully declarative WireMock setup,
+supports multiple `WireMockServer` instances,
+automatically sets Spring environment properties,
+and does not pollute Spring application context with extra beans.
+
+Example:
+
+```java
+@SpringBootTest
+@EnableWireMock({
+    @ConfigureWireMock(name = "user-service", property = "user-client.url")
+})
+class TodoControllerTests {
+
+    @InjectWireMock("user-service")
+    private WireMockServer wiremock;
+    
+    @Autowired
+    private Environment env;
+
+    @Test
+    void aTest() {
+        // returns a URL to WireMockServer instance
+        env.getProperty("user-client.url"); 
+        wiremock.stubFor(stubFor(get("/todolist").willReturn(aResponse()
+                .withHeader("Content-Type", "application/json")
+                .withBody("""
+                        [
+                            { "id": 1, "userId": 1, "title": "my todo" },
+                        ]
+                        """)
+        )));
+    }
+}
+```
+
+## Spring Cloud Contract
 
 The team behind Spring Cloud Contract have created a library to support running WireMock using the "ambient" HTTP server.
 It also simplifies some aspects of configuration and eliminates some common issues that occur when running Spring Boot and WireMock together.


### PR DESCRIPTION
Apparently I forgot to do it in May @maciejwalkowiak 

![image](https://github.com/wiremock/wiremock.org/assets/3000480/00ff8215-d454-4e80-b71b-56090cc94c95)

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
