### PR TITLE
Rust solutions page

### DIFF
--- a/_docs/solutions/rust.md
+++ b/_docs/solutions/rust.md
@@ -75,3 +75,11 @@ References:
 - Crates: [`stubr`](https://crates.io/crates/stubr)
 - [Documentation](https://beltram.github.io/stubr/html/)
 - [GitHub Repository](https://github.com/beltram/stubr)
+
+## Testcontainers module
+
+We are interested in providing a Testcontainers for Rust module that
+would provide SDK for the official [WireMock Docker images]().
+This module is on our roadmap but have not been published yet,
+see [wiremock/ecosystem #8](https://github.com/wiremock/ecosystem/issues/8).
+Contributions are welcome!

--- a/_docs/solutions/rust.md
+++ b/_docs/solutions/rust.md
@@ -4,5 +4,74 @@ title: "WireMock and Rust"
 meta_title: "Rust Solutions | WireMock"
 description: "Additional solutions for WireMock when using Rust"
 logo: /images/logos/technology/rust.svg
-coming-soon: true
 ---
+
+## wiremock-rs. Server implementation in Rust
+
+[LukeMathWalker/wiremock-rs](https://github.com/LukeMathWalker/wiremock-rs) is an API Mock Server implementation in Rust.
+It provides HTTP mocking to perform black-box testing of Rust applications that interact with third-party APIs.
+
+This project is inspired by WireMock and has the same name in the documentation,
+but it is not compatible with WireMock when it comes to CLI, REST API or configuration files.
+Please refer to its documentation for more details and guidelines.
+
+```rust
+use wiremock::{MockServer, Mock, ResponseTemplate};
+use wiremock::matchers::{method, path};
+
+#[async_std::main]
+async fn main() {
+    // Start a background HTTP server on a random local port
+    let mock_server = MockServer::start().await;
+
+    // Arrange the behaviour of the MockServer adding a Mock:
+    // when it receives a GET request on '/hello' it will respond with a 200.
+    Mock::given(method("GET")).and(path("/hello"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&mock_server).await;
+
+    // Verify the response
+    let status = surf::get(format!("{}/hello", &mock_server.uri()))
+        .await.unwrap().status();
+    assert_eq!(status.as_u16(), 200);
+}
+```
+
+References:
+
+- Crates: [`wiremock`](https://crates.io/crates/wiremock)
+- Documentation: [docs.rs/wiremock](https://docs.rs/wiremock/latest/wiremock/)
+- GitHub: [LukeMathWalker/wiremock-rs](https://github.com/LukeMathWalker/wiremock-rs)
+
+## Stubr
+
+[Stubr](https://github.com/beltram/stubr) is an adaptation of `wiremock-rs`
+supporting existing WireMock json stubs as input.
+It aims at reaching feature parity with WireMock.
+The project also provides support for gRPC and offers Docker images.
+
+```rust
+use asserhttp::*;
+
+#[tokio::test]
+async fn getting_started() {
+    // run a mock server with the stub 👇
+    let stubr = stubr::Stubr::start("tests/stubs/hello.json").await;
+    // or use 'start_blocking' for a non-async version
+
+    // the mock server started on a random port e.g. '127.0.0.1:43125'
+    // so we use the stub instance 'path' (or 'uri') method to get the address back
+    let uri = stubr.path("/hello");
+    reqwest::get(uri).await
+        // (optional) use asserhttp for assertions
+        .expect_status_ok()
+        .expect_content_type_text()
+        .expect_body_text_eq("Hello stubr");
+}
+```
+
+References:
+
+- Crates: [`stubr`](https://crates.io/crates/stubr)
+- [Documentation](https://beltram.github.io/stubr/html/)
+- [GitHub Repository](https://github.com/beltram/stubr)

--- a/_docs/solutions/rust.md
+++ b/_docs/solutions/rust.md
@@ -79,7 +79,7 @@ References:
 ## Testcontainers module
 
 We are interested in providing a Testcontainers for Rust module that
-would provide SDK for the official [WireMock Docker images]().
+would provide SDK for the official [WireMock Docker images](../../docker).
 This module is on our roadmap but have not been published yet,
 see [wiremock/ecosystem #8](https://github.com/wiremock/ecosystem/issues/8).
 Contributions are welcome!


### PR DESCRIPTION
Adds https://github.com/LukeMathWalker/wiremock-rs from @LukeMathWalker and https://github.com/beltram/stubr from @beltram to the documentation, and also references the RFE for the Testcontainers Rust module


## Screenshots

![localhost_4000_docs_solutions_rust_](https://github.com/wiremock/wiremock.org/assets/3000480/7ea639b7-9bf0-4b04-9564-d5114d24bad4)


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
