### PR TITLE
Update junit-jupiter.md

### DIFF
--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -168,7 +168,15 @@ The JUnit Jupiter extension can be configured to enable "proxy mode" which simpl
 ### Declarative
 
 In declarative mode this is done by setting the `proxyMode = true` in the annotation declaration. Then, provided your app's
-HTTP client honours the JVM's proxy system properties, you can specify different domain (host) names when creating stubs:
+HTTP client honours the JVM's proxy system properties, you can specify different domain (host) names when creating stubs.
+
+### Programmatic
+
+Proxy mode can be enabled via the extension builder when using the programmatic form.
+
+{% codetabs %}
+
+{% codetab Declarative %}
 
 ```java
 @WireMockTest(proxyMode = true)
@@ -205,9 +213,9 @@ public class JUnitJupiterExtensionJvmProxyDeclarativeTest {
 }
 ```
 
-### Programmatic
+{% endcodetab %}
 
-Proxy mode can be enabled via the extension builder when using the programmatic form:
+{% codetab Programmatic %}
 
 ```java
 public class JUnitJupiterProgrammaticProxyTest {
@@ -247,6 +255,10 @@ public class JUnitJupiterProgrammaticProxyTest {
   }
 }
 ```
+
+{% endcodetab %}
+
+{% endcodetabs %}
 
 ## Subclassing the extension
 


### PR DESCRIPTION
Reducing vertical space in documentation for code examples using code tabs.

## References

- Related to #183 

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [X] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
