### PR TITLE
Code tabs in stub-metadata.md

### DIFF
--- a/_docs/stub-metadata.md
+++ b/_docs/stub-metadata.md
@@ -103,10 +103,9 @@ removeStubsByMetadata(matchingJsonPath("$.singleItem", containing("123")));
 
 {% codetab JSON %}
 
-```json
-
 POST /__admin/mappings/remove-by-metadata
 
+```json
 {
     "matchesJsonPath" : {
       "expression" : "$.singleItem",

--- a/_docs/stub-metadata.md
+++ b/_docs/stub-metadata.md
@@ -12,7 +12,9 @@ It is possible to attach arbitrary metadata to stub mappings, which can be later
 
 Data under the `metadata` key is a JSON object (represented in Java by a `Map<String, ?>`). It can be added to a stub mapping on creation.
 
-Java:
+{% codetabs %}
+
+{% codetab Java %}
 
 ```java
 stubFor(get("/with-metadata")
@@ -25,7 +27,9 @@ stubFor(get("/with-metadata")
 ));
 ```
 
-JSON:
+{% endcodetab %}
+
+{% codetab JSON %}
 
 ```json
 {
@@ -46,19 +50,27 @@ JSON:
 }
 ```
 
+{% endcodetab %}
+
+{% endcodetabs %}
+
 ## Search for stubs by metadata
 
 Stubs can be found by matching against their metadata using the same matching strategies as when [matching HTTP requests](../request-matching/).
 The most useful matcher for this is `matchesJsonPath`:
 
-Java:
+{% codetabs %}
+
+{% codetab Java %}
 
 ```java
 List<StubMapping> stubs =
     findStubsByMetadata(matchingJsonPath("$.singleItem", containing("123")));
 ```
 
-API:
+{% endcodetab %}
+
+{% codetab JSON %}
 
 ```json
 POST /__admin/mappings/find-by-metadata
@@ -71,19 +83,28 @@ POST /__admin/mappings/find-by-metadata
 }
 ```
 
+{% endcodetab %}
+
+{% endcodetabs %}
+
 ## Remove stubs by metadata
 
 Similarly, stubs with matching metadata can be removed:
 
-Java:
+{% codetabs %}
+
+{% codetab Java %}
 
 ```java
 removeStubsByMetadata(matchingJsonPath("$.singleItem", containing("123")));
 ```
 
-API:
+{% endcodetab %}
+
+{% codetab JSON %}
 
 ```json
+
 POST /__admin/mappings/remove-by-metadata
 
 {
@@ -93,6 +114,10 @@ POST /__admin/mappings/remove-by-metadata
     }
 }
 ```
+
+{% endcodetab %}
+
+{% endcodetabs %}
 
 ## Remove request journal events by metadata
 


### PR DESCRIPTION
Reducing vertical space in documentation for code examples using code tabs.

## References

- Related to #183 

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [X] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
