### PR TITLE
Update custom-matching.md

### DIFF
--- a/_docs/extensibility/custom-matching.md
+++ b/_docs/extensibility/custom-matching.md
@@ -70,12 +70,18 @@ public class BodyLengthMatcher extends RequestMatcherExtension {
 
 Then define a stub with it:
 
+{% codetabs %}
+
+{% codetab Java %}
+
 ```java
 stubFor(requestMatching("body-too-long", Parameters.one("maxLength", 2048))
         .willReturn(aResponse().withStatus(422)));
 ```
 
-or via JSON:
+{% endcodetab %}
+
+{% codetab JSON %}
 
 ```json
 {
@@ -93,6 +99,10 @@ or via JSON:
 }
 ```
 
+{% endcodetab %}
+
+{% endcodetabs %}
+
 ### Combining standard and custom request matchers
 
 An inline custom matcher can be used in combination with standard matchers in the following way:
@@ -108,7 +118,9 @@ WireMock server. An exception will be thrown if attempting to use an inline cust
 
 Custom matchers defined as extensions can also be combined with standard matchers.
 
-Java:
+{% codetabs %}
+
+{% codetab Java %}
 
 ```java
 stubFor(get(urlPathMatching("/the/.*/one"))
@@ -116,7 +128,9 @@ stubFor(get(urlPathMatching("/the/.*/one"))
         .willReturn(ok()));
 ```
 
-JSON:
+{% endcodetab %}
+
+{% codetab JSON %}
 
 ```json
 {
@@ -135,3 +149,7 @@ JSON:
     }
 }
 ```
+
+{% endcodetab %}
+
+{% endcodetabs %}


### PR DESCRIPTION
Reducing vertical space in documentation for code examples using code tabs.

## References

- Related to #183 

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [X] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
