### PR TITLE
Update transforming-responses.md

### DIFF
--- a/_docs/extensibility/transforming-responses.md
+++ b/_docs/extensibility/transforming-responses.md
@@ -64,6 +64,10 @@ intend to register them via an instance as described below.
 
 Parameters are supplied on a per stub mapping basis:
 
+{% codetabs %}
+
+{% codetab Java %}
+
 ```java
 stubFor(get(urlEqualTo("/transform")).willReturn(
         aResponse()
@@ -71,7 +75,9 @@ stubFor(get(urlEqualTo("/transform")).willReturn(
                 .withTransformerParameter("inner", ImmutableMap.of("thing", "value")))); // ImmutableMap is from Guava, but any Map will do
 ```
 
-or:
+{% endcodetab %}
+
+{% codetab JSON %}
 
 ```json
 {
@@ -91,6 +97,10 @@ or:
 }
 ```
 
+{% endcodetab %}
+
+{% endcodetabs %}
+
 ### Non-global transformations
 
 By default transformations will be applied globally. If you only want
@@ -106,6 +116,10 @@ public boolean applyGlobally() {
 
 Then you add the transformation to specific stubs via its name:
 
+{% codetabs %}
+
+{% codetab Java %}
+
 ```java
 stubFor(get(urlEqualTo("/local-transform")).willReturn(aResponse()
         .withStatus(200)
@@ -113,7 +127,9 @@ stubFor(get(urlEqualTo("/local-transform")).willReturn(aResponse()
         .withTransformers("my-transformer", "other-transformer")));
 ```
 
-or:
+{% endcodetab %}
+
+{% codetab JSON %}
 
 ```json
 {
@@ -128,6 +144,9 @@ or:
     }
 }
 ```
+{% endcodetab %}
+
+{% endcodetabs %}
 
 The Java API also has a convenience method for adding transformers and
 parameters in one call:


### PR DESCRIPTION
Reducing vertical space in documentation for code examples using code tabs.

## References

- Related to #183 

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [X] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
