### PR TITLE
Update transforming-responses.md

### DIFF
--- a/_docs/extensibility/transforming-responses.md
+++ b/_docs/extensibility/transforming-responses.md
@@ -36,10 +36,10 @@ booleans, maps and lists) can be used.
 
 ## Response definition transformation
 
-To transform `ResponseDefinition` extend the `ResponseDefinitionTransformerV2` class:
+To transform `ResponseDefinition` implement the `ResponseDefinitionTransformerV2` interface:
 
 ```java
-public static class ExampleTransformer extends ResponseDefinitionTransformerV2 {
+public static class ExampleTransformer implements ResponseDefinitionTransformerV2 {
 
         @Override
         public ResponseDefinition transform(ServeEvent serveEvent) {
@@ -165,7 +165,7 @@ A response transformer extension class is identical to `ResponseDefinitionTransf
 This transformer is the best option if you want to transform the response from a proxy call.
 
 ```java
-public static class StubResponseTransformerWithParams extends ResponseTransformerV2 {
+public static class StubResponseTransformerWithParams implements ResponseTransformerV2 {
 
         @Override
         public Response transform(Response response, ServeEvent serveEvent) {


### PR DESCRIPTION
Fixed documentation as ResponseDefinitionTransformerV2 and ResponseTransformerV2 are interfaces.

## References

- There is no issue opened for this

## Submitter checklist

- [ x] The PR request is well described and justified, including the body and the references
- [x ] The PR title represents the desired changelog entry
- [x ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
