### PR TITLE
documentation for wiremock options as env variable in docker

### DIFF
--- a/_docs/standalone/docker.md
+++ b/_docs/standalone/docker.md
@@ -39,7 +39,7 @@ docker run -it --rm \
 
 #### Passing command line arguments as environment variable
 
-The Docker image supports passing command line arguments [standalone version](../java-jar#command-line-options) as the environment variable.
+Starting from `3.2.0-2`, the Docker image supports passing command line arguments [standalone version](../java-jar#command-line-options) as the environment variable.
 Environment variable `WIREMOCK_OPTIONS` can be passed to container consisting of all command line arguments e.g.:
 
 ```sh

--- a/_docs/standalone/docker.md
+++ b/_docs/standalone/docker.md
@@ -37,6 +37,19 @@ docker run -it --rm \
   --https-port 8443 --verbose
 ```
 
+#### Command line argument in environment variable WIREMOCK_OPTIONS
+
+The Docker image supports passing command line arguments [standalone version](../java-jar#command-line-options) as the environment variable.
+Environment variable WIREMOCK_OPTIONS can be passed to container consisting of all command line arguments e.g.:
+
+```sh
+docker run -it --rm \
+  -e WIREMOCK_OPTIONS='--https-port 8443 --verbose'
+  -p 8443:8443 \
+  --name wiremock \
+  wiremock/wiremock:{{ site.wiremock_version }}
+```
+
 ### Mounting stub mapping files
 
 Inside the container, the WireMock uses `/home/wiremock` as the root from which it reads the `mappings` and `__files` directories.

--- a/_docs/standalone/docker.md
+++ b/_docs/standalone/docker.md
@@ -40,7 +40,7 @@ docker run -it --rm \
 #### Passing command line arguments as environment variable
 
 The Docker image supports passing command line arguments [standalone version](../java-jar#command-line-options) as the environment variable.
-Environment variable WIREMOCK_OPTIONS can be passed to container consisting of all command line arguments e.g.:
+Environment variable `WIREMOCK_OPTIONS` can be passed to container consisting of all command line arguments e.g.:
 
 ```sh
 docker run -it --rm \

--- a/_docs/standalone/docker.md
+++ b/_docs/standalone/docker.md
@@ -37,7 +37,7 @@ docker run -it --rm \
   --https-port 8443 --verbose
 ```
 
-#### Command line argument in environment variable WIREMOCK_OPTIONS
+#### Passing command line arguments as environment variable
 
 The Docker image supports passing command line arguments [standalone version](../java-jar#command-line-options) as the environment variable.
 Environment variable WIREMOCK_OPTIONS can be passed to container consisting of all command line arguments e.g.:


### PR DESCRIPTION
Adds documentation for passing command line options as ENV variable WIREMOCK_OPTIONS to docker container.

## References
Documentation for https://github.com/wiremock/wiremock-docker/issues/78

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)
