### PR TITLE
Add missing bash line continuation to a "WireMock in Docker" example

### DIFF
--- a/_docs/standalone/docker.md
+++ b/_docs/standalone/docker.md
@@ -44,7 +44,7 @@ Environment variable `WIREMOCK_OPTIONS` can be passed to container consisting of
 
 ```sh
 docker run -it --rm \
-  -e WIREMOCK_OPTIONS='--https-port 8443 --verbose'
+  -e WIREMOCK_OPTIONS='--https-port 8443 --verbose' \
   -p 8443:8443 \
   --name wiremock \
   wiremock/wiremock:{{ site.wiremock_version }}


### PR DESCRIPTION
The documentation is missing a line continuation from the example "[Passing command-line arguments as environment variable](https://wiremock.org/docs/standalone/docker/#passing-command-line-arguments-as-environment-variable)"

This PR adds the missing `\` character so the command can be copy-pasted into a terminal.

## References

Original PR for the documentation: https://github.com/wiremock/wiremock.org/pull/216

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
