### PR TITLE
outdated documentation for ResponseTemplateTransformer

### DIFF
--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -909,8 +909,8 @@ then you can use the `ResponseTemplateTransformer` when constructing the respons
 The `ResponseTemplateTransformer` accepts four arguments:
 1. The `TemplateEngine`
 2. If templating can be applied globally
-3. The `FileSource`
-4. A list of `TemplateModelDataProviderExtension` objects
+3. The `FileSource` which is a list of files that can be used for relative references in stub definitions
+4. A list of `TemplateModelDataProviderExtension` objects which are additional metadata providers which will be injected into the model and consumed in the downstream resolution if needed
 
 ```java
 @Rule

--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -903,22 +903,26 @@ Environment variables and system properties can be printed:
 
 {% endraw %}
 
-To avoid disclosure of sensitive variables, only permitted variables can be read. Permitted variable names
-are defined via a set of regular expressions. These can be configured when constructing the response template extension:
+If you want to add permitted extensions to your rule,
+then you can use the `ResponseTemplateTransformer` when constructing the response template extension.
+
+The `ResponseTemplateTransformer` accepts four arguments:
+1. The `TemplateEngine`
+2. If templating can be applied globally
+3. The `FileSource`
+4. A list of `TemplateModelDataProviderExtension` objects
 
 ```java
 @Rule
 public WireMockRule wm = new WireMockRule(options()
         .dynamicPort()
         .withRootDirectory(defaultTestFilesRoot())
-        .extensions(new ResponseTemplateTransformer.Builder()
-                .global(true)
-                .permittedSystemKeys("allowed.*","also_permitted.*")
-                .build()
+        .extensions(new ResponseTemplateTransformer(
+              getTemplateEngine(),
+              options.getResponseTemplatingGlobal(),
+              getFiles(),
+              templateModelProviders
+            )
         )
 );
 ```
-
-The regular expressions are matched in a case-insensitive manner.
-
-If no permitted system key patterns are set, a single default of `wiremock.*` will be used.


### PR DESCRIPTION
The section about the ResponseTemplateTransformer in the [documentation](https://wiremock.org/docs/response-templating/) is not correct for WireMock 3.0. As such, it was needed to update it accordingly. This is what this PR aims to do.

## References

Fixes #210 

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
