### PR TITLE
ci: automate wiremock version update

### DIFF
--- a/.github/updatecli/updatecli.d/wiremock.yaml
+++ b/.github/updatecli/updatecli.d/wiremock.yaml
@@ -1,0 +1,66 @@
+name: 'docs: bump wiremock version used in the documentation'
+pipelineid: "wiremock"
+
+actions:
+  default:
+    title: 'docs: update Wiremock version to {{ source "wiremock" }}'
+    kind: github/pullrequest
+    scmid: default
+    spec:
+      automerge: false
+      mergemethod: squash
+      labels:
+        - chore
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: wiremock-bot
+      email: bot@wiremock.io
+      owner: wiremock
+      repository: wiremock.org
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      branch: main
+
+sources:
+  wiremock:
+    name: Get latest Wiremock version
+    kind: githubrelease
+    spec:
+      owner: wiremock
+      repository:  wiremock 
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      versionfilter:
+        kind: semver
+
+conditions:
+  docker:
+    name: 'Check that a docker image is available for the latest version'
+    kind: dockerimage
+    spec:
+      image: wiremock/wiremock
+      architecture: amd64
+
+targets:
+  wiremock_version:
+    name: 'docs: update Wiremock version to {{ source "wiremock" }}'
+    kind: yaml
+    scmid: default
+    spec:
+      file: _config.yml
+      key: "$.wiremock_version"
+
+  wiremock_baseline:
+    name: 'docs: update Wiremock baseline to {{ source "wiremock" }}'
+    kind: yaml
+    scmid: default
+    spec:
+      file: _config.yml
+      key: "$.wiremock_baseline"
+    transformers:
+      - findsubmatch:
+          pattern: '^(\d*).'
+          captureindex: 1
+      - addsuffix: '.x'

--- a/.github/updatecli/updatecli.d/wiremock.yaml
+++ b/.github/updatecli/updatecli.d/wiremock.yaml
@@ -1,23 +1,23 @@
-name: 'docs: bump wiremock version used in the documentation'
+name: 'Bump WireMock version'
 pipelineid: "wiremock"
 
 actions:
   default:
-    title: 'docs: update Wiremock version to {{ source "wiremock" }}'
+    title: 'docs: update WireMock version to {{ source "wiremock" }}'
     kind: github/pullrequest
     scmid: default
     spec:
       automerge: false
       mergemethod: squash
       labels:
-        - chore
+        - documentation
 
 scms:
   default:
     kind: github
     spec:
       user: wiremock-bot
-      email: bot@wiremock.io
+      email: release-bot@wiremock.org
       owner: wiremock
       repository: wiremock.org
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
@@ -26,7 +26,7 @@ scms:
 
 sources:
   wiremock:
-    name: Get latest Wiremock version
+    name: Get latest WireMock version
     kind: githubrelease
     spec:
       owner: wiremock
@@ -45,7 +45,7 @@ conditions:
 
 targets:
   wiremock_version:
-    name: 'docs: update Wiremock version to {{ source "wiremock" }}'
+    name: 'docs: update WireMock version to {{ source "wiremock" }}'
     kind: yaml
     scmid: default
     spec:
@@ -53,7 +53,7 @@ targets:
       key: "$.wiremock_version"
 
   wiremock_baseline:
-    name: 'docs: update Wiremock baseline to {{ source "wiremock" }}'
+    name: 'docs: update WireMock baseline to {{ source "wiremock" }}'
     kind: yaml
     scmid: default
     spec:

--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -1,0 +1,32 @@
+---
+name: "Updatecli"
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # trigger every hour the following pipeline
+    - cron: '0 * * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    # Ensure we only run the following pipeline from main branch
+    # with a GITHUB_TOKEN that has "contents: write" permission
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Updatecli Binary
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli in enforce mode
+        run: "updatecli apply --config .github/updatecli/updatecli.d"
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
fix #171 

This pullrequest introduces [Updatecli](github.com/updatecli/updatecli) to automate Wiremock version update.
Updatecli will monitor Wiremock releases and if something change, it will create a temporary branch, and a open a pull request targeting `main` with suggested change. If anything goes wrong, we can still refuse the PR or disable Updatecli later on

To work we need two things:

**An Updatecli GitHub workflow**
Updatecli is command line tool, the workflow can be triggered either manually with the workflow_dispatch event or via the cronjob every hour. Each time Updatecli is executed, it loads manifests that describe update pipeline.

**An Updatecli manifest**

The manifest describes

1. Where the `source` information comes from, in this case the Wiremock latest GitHub release
2. Validate  `conditions`, in this case that a docker image exist for the retrieved version
3. Update if necessary the `targets`. In this case we have a file named "_config.yml" with two information to update
4. The configuration for the pullrequest (actions)
5. The git repository to interact with (scms)

I executed the Updatecli command locally to see what would be changed 

<details><summary>Console Output</summary>

```
 => updatecli diff --config updatecli/updatecli.d/


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/wiremock.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#########################################################
# DOCS: BUMP WIREMOCK VERSION USED IN THE DOCUMENTATION #
#########################################################


SOURCES
=======

wiremock
--------
Searching for version matching pattern "*"
✔ GitHub release version "3.2.0" found matching pattern "*" of kind "semver"


CHANGELOG:
----------

Release published on the 2023-09-27 14:49:16 +0000 UTC at the url https://github.com/wiremock/wiremock/releases/tag/3.2.0

<!-- Optional: add a release summary here -->
## 💥 Breaking changes

* Enable local response templating by default in standalone (#2386) @tomakehurst
* Add startup option to enable/disable extension scanning and set to disabled by default when running from Java (#2385) @tomakehurst

## 🚀 New features and improvements

* Exposing MappingsLoader as an extension point (#2334) @bharatnpti
* Include more info when webhook refusal logged (#2389) @Mahoney
* HTTP Server Factory as an extension point (#2391) @tomakehurst
* Print loaded extensions at startup (#2381) @tomakehurst

## 🐛 Bug fixes

* Fix json string schema rejecting numbers (#2390) @Mahoney
* Fix FileSource backed blobstore keys bug (#2392) @tomakehurst
* Fixed #2388 - empty getPath() returned from new FileStore implementation passed to transformers (#2396) @tomakehurst

## 📦 Dependency updates

* Bump io.netty:netty-all from 4.1.97.Final to 4.1.98.Final (#2394) @dependabot



CONDITIONS:
===========

docker
------
✔ docker image wiremock/wiremock:3.2.0 found


TARGETS
========

wiremock_version
----------------

**Dry Run enabled**

✔ - key "$.wiremock_version" already set to "3.2.0", from file "_config.yml"

wiremock_baseline
-----------------

**Dry Run enabled**

✔ - key "$.wiremock_baseline" already set to "3.x", from file "_config.yml"


ACTIONS
========


=============================

REPORTS:



✔ docs: bump wiremock version used in the documentation:
	Source:
		✔ [wiremock] Get latest Wiremock version
	Condition:
		✔ [docker] Check that a docker image is available for the latest version
	Target:
		✔ [wiremock_baseline] docs: update Wiremock version to 3.2.0
		✔ [wiremock_version] docs: update Wiremock version to 3.2.0


Run Summary
===========
Pipeline(s) run:
  * Changed:	0
  * Failed:	0
  * Skipped:	0
  * Succeeded:	1
  * Total:	1

```

</details>

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
