### PR TITLE
Add NPM to distributions list

### DIFF
--- a/_docs/index.html
+++ b/_docs/index.html
@@ -111,7 +111,7 @@ description: >
         <img src="{{ '/images/wiremock-cloud/wiremock_cloud_favicon.svg' | absolute_url }}">
         WireMock Cloud (commercial SaaS)
     </a>
-    <a class="card" href="./solutions/nodejs">
+    <a class="card" href="https://www.npmjs.com/package/wiremock"  target="_blank">
         <img src="{{ '/images/logos/technology/npm.svg' | absolute_url }}">
         NPM
     </a>

--- a/_docs/index.html
+++ b/_docs/index.html
@@ -111,6 +111,10 @@ description: >
         <img src="{{ '/images/wiremock-cloud/wiremock_cloud_favicon.svg' | absolute_url }}">
         WireMock Cloud (commercial SaaS)
     </a>
+    <a class="card" href="./solutions/nodejs">
+        <img src="{{ '/images/logos/technology/npm.svg' | absolute_url }}">
+        NPM
+    </a>
 </div>
 
 <h2>By use-case</h2>

--- a/images/logos/technology/npm.svg
+++ b/images/logos/technology/npm.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 10V20H9V22H16V20H32V10H0Z" fill="#CB3837"/>
+<path d="M5.46205 12H2V18H5.46205V13.6111H7.22344V18H8.98482V12H5.46205ZM10.7462 12V20H14.269V18H17.731V12H10.7462ZM15.9696 16.3889H14.269V13.6111H15.9696V16.3889ZM22.9545 12H19.4924V18H22.9545V13.6111H24.7158V18H26.4772V13.6111H28.2386V18H30V12H22.9545Z" fill="white"/>
+</svg>


### PR DESCRIPTION
This PR adds the NPM distribution of WireMock to the official documentation, specifically in the list of available distributions on the WireMock website which links to the Node.js solutions page.


Closes: wiremock/wiremock-npm#5


## References

- [wiremock/wiremock-npm](https://github.com/wiremock/wiremock-npm)

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
