### PR TITLE
Update java-jar.md

### DIFF
--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -329,7 +329,7 @@ src/main/resources/wiremock-stuff/mappings
 You could then run the packaged JAR as:
 
 ```
-java -jar custom-wiremock.jar --load-resources-from-classpath 'wiremock-stuff'
+java -jar custom-wiremock.jar --load-resources-from-classpath wiremock-stuff
 ```
 
 Which will load your files and mappings from the packaged JAR.


### PR DESCRIPTION
'wiremock' phrase leads to a misunderstanding. Because the usage -> 'wiremock' is not valid in command line. And in this case while wiremock server is up, user is getting no mapping found error when (s)he has made an http call. Perhaps user should know 'wiremock' usage is invalid in command line. But I have spent four hours to figure it out because I was tired. :)

<!-- Please describe your pull request here. -->

## References

- TODO

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
