### PR TITLE
Remove extra stubFor() in spring-boot example

### DIFF
--- a/_docs/solutions/spring-boot.md
+++ b/_docs/solutions/spring-boot.md
@@ -37,14 +37,14 @@ class TodoControllerTests {
     void aTest() {
         // returns a URL to WireMockServer instance
         env.getProperty("user-client.url"); 
-        wiremock.stubFor(stubFor(get("/todolist").willReturn(aResponse()
+        wiremock.stubFor(get("/todolist").willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
                 .withBody("""
                         [
                             { "id": 1, "userId": 1, "title": "my todo" },
                         ]
                         """)
-        )));
+        ));
     }
 }
 ```


### PR DESCRIPTION
This commit  removes an extra stubFor() in the code example. It was added twice by mistake and causes a compilation error.

## References

https://github.com/wiremock/wiremock.org/issues/240

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [NA] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [X] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
