### PR TITLE
Add extensionScanningEnabled option to @WireMockTest.

### DIFF
--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -79,6 +79,18 @@ public class HttpsFixedPortDeclarativeWireMockTest {
 }
 ```
 
+### Enabling Extension Scanning
+
+When [extending WireMock via service loading](extending-wiremock.md#extension-registration-via-service-loading), it may
+be helpful to have WireMock scan for extensions automatically via the `extensionScanningEnabled` parameter.
+
+```java
+@WireMockTest(extensionScanningEnabled = true)
+public class ExtensionScanningDeclarativeWireMockTest {
+    ...
+}
+```
+
 ## Advanced usage - programmatic
 
 Invoking the extension programmatically with `@RegisterExtension` allows you to run any number of WireMock instances and provides full control


### PR DESCRIPTION
When using extensions that utilize service loading (e.g. [wiremock/wiremock-graphql-extension](https://github.com/wiremock/wiremock-graphql-extension)) it would be preferable to use the declarative option to enable extension scanning, rather than being forced to use the programmatic approach to manually define extensions.

## References

- https://github.com/wiremock/wiremock/pull/2561

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
