### PR TITLE
Corrected getRequestURI to url for wiremock server example test.

### DIFF
--- a/_docs/quickstart/java-junit.md
+++ b/_docs/quickstart/java-junit.md
@@ -100,7 +100,7 @@ public void exampleTest() {
     // Setup HTTP POST request (with HTTP Client embedded in Java 11+)
     final HttpClient client = HttpClient.newBuilder().build();
     final HttpRequest request = HttpRequest.newBuilder()
-        .uri(wiremockServer.getRequestURI("/my/resource"))
+        .uri(wiremockServer.url("/my/resource"))
         .header("Content-Type", "text/xml")
         .POST().build();
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Closes #238 . This PR corrects a mistake in documentation at https://wiremock.org/docs/quickstart/java-junit/. WireMockServer has no getRequestURI. Thus it is corrected to url in test example in doc.

## References

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
