### PR TITLE
Added documentation for GET_OR_HEAD method

### DIFF
--- a/_docs/stubbing.md
+++ b/_docs/stubbing.md
@@ -133,8 +133,26 @@ stubFor(put("/status-only")
 More DSL examples [can be found here](https://github.com/tomakehurst/wiremock/tree/master/src/test/java/ignored/Examples.java#374).
 
 HTTP methods currently supported are:
-`GET, POST, PUT, DELETE, HEAD, TRACE, OPTIONS`. You can specify `ANY` if
-you want the stub mapping to match on any request method.
+`GET, POST, PUT, DELETE, HEAD, TRACE, OPTIONS, GET_OR_HEAD`. You can specify `ANY` if
+you want the stub mapping to match on any request method. `GET_OR_HEAD` is a special
+method that could be used to match incoming requests for both `GET` or `HEAD` http
+method. It can be used the following way
+
+{% codetabs %}
+
+{% codetab Java %}
+
+```java
+@Test
+public void getOrHeadDemo() {
+	stubFor(getOrHead(urlEqualTo("/get-or-head-test"))
+            .willReturn(okJson("{\"key\": \"value\"}")));
+	
+	assertThat(testClient.get("/get-or-head-test").statusCode(), is(200));
+}
+```
+
+{% endcodetab %}
 
 ### Setting the response status message
 

--- a/_docs/stubbing.md
+++ b/_docs/stubbing.md
@@ -136,7 +136,10 @@ HTTP methods currently supported are:
 `GET, POST, PUT, DELETE, HEAD, TRACE, OPTIONS, GET_OR_HEAD`. You can specify `ANY` if
 you want the stub mapping to match on any request method. `GET_OR_HEAD` is a special
 method that could be used to match incoming requests for both `GET` or `HEAD` http
-method. It can be used the following way
+method. A ```HEAD``` request will result in the same behaviour expected from a web server i.e.
+the ```Content-Type``` and ```Content-Length``` headers will be emitted but no response body.
+A detailed guide about various HTTP methods can be found [here](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods).
+```GET_OR_HEAD``` can be used the following way
 
 {% codetabs %}
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Closes #245 . This PR adds documentation for the ```GET_OR_HEAD``` method

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
