### PR TITLE
fix stub mapping http endpoint

### DIFF
--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -212,7 +212,7 @@ You can create a stub mapping by posting to WireMock's HTTP API:
 ```bash
 $ curl -X POST \
 --data '{ "request": { "url": "/get/this", "method": "GET" }, "response": { "status": 200, "body": "Here it is!\n" }}' \
-http://localhost:8080/__admin/mappings/new
+http://localhost:8080/__admin/mappings
 ```
 
 And then fetch it back:


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This was seemingly changed at some point (based on https://github.com/wiremock/wiremock/issues/253#issuecomment-84376794) and I'm guessing this got missed because it is corrected elsewhere in the documentation.

## References

https://wiremock.org/docs/stubbing/#basic-stubbing:
```md

You can configure stubs using JSON configuration files or code:

1. Via a `.json` file under the `mappings` directory
2. Via a POST request to
`http://<host>:<port>/__admin/mappings` with the JSON as a body
3. From code using one of the SDKs
```

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
