### PR TITLE
Allow matchesJsonSchema to be supplied as a json object.

### DIFF
--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -800,7 +800,38 @@ stubFor(
     .willReturn(ok()));
 ```
 
-JSON:
+JSON (supported in 3.4+):
+
+```json
+{
+  "request" : {
+    "urlPath" : "/schema-match",
+    "method" : "POST",
+    "bodyPatterns" : [ {
+      "matchesJsonSchema" : {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "schemaVersion" : "V202012"
+    } ]
+  },
+  "response" : {
+    "status" : 200
+  }
+}
+```
+
+JSON with string literal:
 
 ```json
 {


### PR DESCRIPTION
Show use of new ability to supply json object to matchesJsonSchema.

## References

- https://github.com/wiremock/wiremock/pull/2566

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
