### PR TITLE
Remove the hacktoberfest masthead

### DIFF
--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -1,22 +1,7 @@
 var wiremock_notification_shown = localStorage.getItem(
   "wiremock_notification_shown",
 );
-var notifications = [
-  {
-    content: {
-      title:
-        "Join us for Hacktoberfest 2023! " +
-        "Adopt WireMock in your projects and contribute to open source. " +
-        "<a href='https://www.wiremock.io/post/hacktoberfest-2023?utm_medium=referral&utm_source=wiremock.org&utm_content=notification' target='_blank'>Learn More</a>",
-    },
-    layout: {
-      style: "wiremock_notification_with_link",
-      position: "top",
-      className: "info",
-      autoHide: false,
-    },
-  },
-];
+var notifications = [];
 
 if (wiremock_notification_shown == null) {
   localStorage.setItem("wiremock_notification_shown", true);


### PR DESCRIPTION
This PR removes the hacktoberfest masthead notification from the notifications…js file.  This is currently empty of notifications until we have something new to add

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
