### PR TITLE
Update stub mappings URL in administration.md

### DIFF
--- a/_docs/standalone/administration.md
+++ b/_docs/standalone/administration.md
@@ -10,7 +10,7 @@ You can find the key use-cases and the full specification below.
 
 ## Fetching all of your stub mappings (and checking WireMock is working)
 
-A GET request to the root admin URL e.g `http://localhost:8080/__admin`
+A GET request to the root admin URL e.g `http://localhost:8080/__admin/mappings`
 will return all currently registered stub mappings.
 This is a useful way to check whether WireMock is running on the host and port you expect.
 

--- a/_docs/standalone/administration.md
+++ b/_docs/standalone/administration.md
@@ -10,7 +10,7 @@ You can find the key use-cases and the full specification below.
 
 ## Fetching all of your stub mappings (and checking WireMock is working)
 
-A GET request to the root admin URL e.g `http://localhost:8080/__admin/mappings`
+A GET request to the mappings admin URL e.g `http://localhost:8080/__admin/mappings`
 will return all currently registered stub mappings.
 This is a useful way to check whether WireMock is running on the host and port you expect.
 


### PR DESCRIPTION
> A GET request to the root admin URL e.g `http://localhost:8080/__admin` will return all currently registered stub mappings. This is a useful way to check whether WireMock is running on the host and port you expect.

This doesn't seem to be correct, I think this URL should be `http://localhost:8080/__admin/mappings` instead? This is what is mentioned on [this page](https://wiremock.org/docs/standalone/docker/) which works for me, whereas the `/__admin` endpoint does not.

## References

- None - simple change so just opened a PR instead of an issue

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
