### PR TITLE
Document disabling response templating per stub

### DIFF
--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -30,8 +30,8 @@ WireMockServer wm =
 
 See [the command line docs](../standalone/java-jar/#command-line-options) for the standalone equivalents of these parameters.
 
-Response templating can also be disabled on a per-stub basis by adding the `disableBodyFileTemplating` parameter to the 
-`transformerParameters` object in the stub response definition.
+Response templating can also be disabled on a per-stub basis when using the `bodyFileName` element by adding the 
+`disableBodyFileTemplating` parameter to the `transformerParameters` object in the stub response definition.
 
 ```json
 {
@@ -41,7 +41,7 @@ Response templating can also be disabled on a per-stub basis by adding the `disa
   },
   "response": {
     "status": 200,
-    "body": "Body content",
+    "bodyFileName": "response.json",
     "transformerParameters": {
       "disableBodyFileTemplating": true
     }

--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -30,6 +30,24 @@ WireMockServer wm =
 
 See [the command line docs](../standalone/java-jar/#command-line-options) for the standalone equivalents of these parameters.
 
+Response templating can also be disabled on a per-stub basis by adding the `disableBodyFileTemplating` parameter to the 
+`transformerParameters` object in the stub response definition.
+
+```json
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/test"
+  },
+  "response": {
+    "status": 200,
+    "body": "Body content",
+    "transformerParameters": {
+      "disableBodyFileTemplating": true
+    }
+  }
+}
+```
 
 ## Customising and extending the template engine
 

--- a/_docs/standalone/docker.md
+++ b/_docs/standalone/docker.md
@@ -123,6 +123,7 @@ services:
     image: "wiremock/wiremock:latest"
     container_name: my_wiremock
     volumes:
+      - ./extensions:/var/wiremock/extensions
       - ./__files:/home/wiremock/__files
       - ./mappings:/home/wiremock/mappings
     entrypoint: ["/docker-entrypoint.sh", "--global-response-templating", "--disable-gzip", "--verbose"]


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR adds a few small updates to the community docs based on some questions that were asked and answered in the community slack recently:

* Update the docker compose example where we map the directories to include the `extensions` directory
* Add an example of disabling response templating on a per stub basis

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
