### PR TITLE
Optional default for SystemValueHelper.

### DIFF
--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -909,8 +909,21 @@ Environment variables and system properties can be printed:
 {% raw %}
 
 ```handlebars
+{{systemValue key='PATH'}} <!-- type defaults to ENVIRONMENT -->
 {{systemValue type='ENVIRONMENT' key='PATH'}}
 {{systemValue type='PROPERTY' key='os.path'}}
+```
+
+{% endraw %}
+
+Since 3.5 a default value can be supplied:
+
+{% raw %}
+
+```handlebars
+{{systemValue key='PATH' default='DEFAULT'}} <!-- type defaults to ENVIRONMENT -->
+{{systemValue type='ENVIRONMENT' key='PATH' default='DEFAULT'}}
+{{systemValue type='PROPERTY' key='os.path' default='DEFAULT'}}
 ```
 
 {% endraw %}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Update documentation to reflect change that allows optional default value to be supplied for the systemValue helper.

## References

- https://github.com/wiremock/wiremock/pull/2630

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
