### PR TITLE
Allow removal of headers from a proxied request.

### DIFF
--- a/_docs/proxying.md
+++ b/_docs/proxying.md
@@ -102,7 +102,7 @@ the request to the destination:
 stubFor(get(urlMatching(".*"))
         .willReturn(aResponse()
             .proxiedFrom("http://otherhost.com")
-            .withAdditionalRequestHeader("User-Agent", "Mozilla/5.0 (iPhone; U; CPU iPhone)"));
+            .withAdditionalRequestHeader("User-Agent", "Mozilla/5.0 (iPhone; U; CPU iPhone)")));
 ```
 
 or
@@ -123,6 +123,35 @@ or
 ```
 
 You can also add response headers via the same method as for non-proxy responses (see [Stubbing](../stubbing/)).
+
+# Remove headers
+
+It is possible to configure the proxy to remove headers before forwarding the reques to the destination
+([additional headers](#additional-headers) matching the removed headers will still be added).
+
+```java
+stubFor(get(urlMatching(".*"))
+        .willReturn(aResponse()
+            .proxiedFrom("http://otherhost.com")
+            .withRemoveRequestHeader("User-Agent")));
+```
+
+or
+
+```json
+{
+    "request": {
+        "method": "GET",
+        "urlPattern": ".*"
+    },
+    "response": {
+        "proxyBaseUrl": "http://otherhost.com",
+        "removeProxyRequestHeaders": [
+            "User-Agent"
+        ]
+    }
+}
+```
 
 ## Standalone shortcut
 


### PR DESCRIPTION
Along with the ability to add additionalProxyRequestHeaders, it may be beneficial to removeProxyRequestHeaders. For example, if you want to remove the existing value(s) of a header before additional are added or if there are headers you don't want sent downstream.

## References

- https://github.com/wiremock/wiremock/pull/2644

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
