### PR TITLE
Update links to JUnit pages

### DIFF
--- a/_docs/quickstart/java-junit.md
+++ b/_docs/quickstart/java-junit.md
@@ -151,6 +151,6 @@ int httpsPort = wireMockRule.httpsPort();
 ## Further reading
 
 - For more details on verifying requests and stubbing responses, see [Stubbing](../../stubbing) and [Verifying](../../verifying/)
-- For more information on the JUnit rules see [The JUnit 4 Rule](../../junit-4/).
+- For more information on the JUnit 5 Jupiter extension see [JUnit 5+ Jupiter](../../junit-jupiter/); for previous JUnit versions you can use [the JUnit 4 Rule](../../junit-extensions/).
 - For many more examples of JUnit tests check out the
 [WireMock's own acceptance tests](https://github.com/wiremock/wiremock/tree/master/src/test/java/com/github/tomakehurst/wiremock)


### PR DESCRIPTION
The links in the [java-junit](https://wiremock.org/docs/quickstart/java-junit/) are outdated, this PR updates them to the latest ones. 

## References

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [X] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
