### PR TITLE
Fix download page frontmatter formatting

### DIFF
--- a/_docs/download-and-installation.md
+++ b/_docs/download-and-installation.md
@@ -4,10 +4,15 @@ title: Download and Installation
 meta_title: "How to Download and Install WireMock"
 toc_rank: 13
 description: >
-WireMock is available as a standalone service (for Docker of Java), Java library
-and integrations for modern languages and technology stacks.
-redirect_from: - "/download.html" - "/download/" - "/downloads.html" - "/downloads/" - "/docs/download.html" - "/docs/download/"
-
+  WireMock is available as a standalone service (for Docker of Java), Java library
+  and integrations for modern languages and technology stacks.
+redirect_from:
+  - "/download.html"
+  - "/download/"
+  - "/downloads.html"
+  - "/downloads/"
+  - "/docs/download.html"
+  - "/docs/download/"
 ---
 
 <div class="cloud-callout"><a href="https://www.wiremock.io?utm_source=oss-docs&utm_medium=oss-docs&utm_campaign=cloud-callouts-install&utm_id=cloud-callouts&utm_term=cloud-callouts-install" target="_BLANK">To create publicly hosted mock APIs without anything to install, learn more about WireMock Cloud.</a></div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR fixes the frontmatter on the wiremock.org download page.  At the moment the link to the download page from the [standalone page](https://wiremock.org/docs/standalone/java-jar/) is not working due to the redirects not being in place

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
