### PR TITLE
Document new helpers and extension lifecycle

### DIFF
--- a/_docs/extending-wiremock.md
+++ b/_docs/extending-wiremock.md
@@ -28,6 +28,10 @@ At present, the following extension interfaces are available:
 
 The interfaces in this list ending with `V2` supercede deprecated equivalents with an older, more restrictive interface. Additionally `ServeEventListener` deprecates `PostServeAction`.
 
+As of WireMock version `3.6.0`, the `Extension` interface has two new lifecycle methods called `start()` and `stop()`. 
+The `start()` method is called on each extension when the WireMock server first starts (just before the stub mappings 
+are loaded) and the `stop()` method is called when the server is stopped. This allows extensions to perform any
+initialisation or cleanup tasks.
 
 ## Registering Extensions
 

--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -786,6 +786,7 @@ You can also specify a `prefix` and `suffix` to be added to the start and end of
 
 ```handlebars
 {{arrayJoin ',' (array 'One' 'Two' 'Three') prefix='[' suffix=']'}} // [One,Two,Three]
+{{arrayJoin ' * ' (array 1 2 3) prefix='(' suffix=')'}} // (1 * 2 * 3)
 ```
 
 {% endraw %}
@@ -807,6 +808,21 @@ The `arrayJoin` helper can also be used as a block helper:
 "name{{item.id}}": "{{item.name}}"
 }
 {{/arrayJoin}}] // [{ "name1": "One" }, { "name2": "Two" }, { "name3": "Three" }]
+
+
+// or the same example with the prefix and suffix parameters
+{{#parseJson 'myThings'}}
+    [
+    { "id": 1, "name": "One" },
+    { "id": 2, "name": "Two" },
+    { "id": 3, "name": "Three" }
+    ]
+{{/parseJson}}
+{{#arrayJoin ',' myThings prefix='[' suffix=']' as |item|}}
+    {
+    "name{{item.id}}": "{{item.name}}"
+    }
+{{/arrayJoin}} // [{ "name1": "One" }, { "name2": "Two" }, { "name3": "Three" }]
 ```
 
 {% endraw %}

--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -341,6 +341,30 @@ Variable assignment and number helpers are available:
 
 {% endraw %}
 
+## Val helper
+
+The `val` helper can be used to access values or provide a default if the value is not present. It can also be used to
+assign a value to a variable much like the `assign` helper.  The main difference between `val` and `assign` is that `val`
+will maintain the type of the date being assigned whereas `assign` will always assign a string.
+
+{% raw %}
+
+```handlebars
+{{val request.query.search or='default'}} // the value of request.query.search or 'default' if it's not present
+{{val request.query.search default='default'}} // the value of request.query.search or 'default' if it's not present
+{{val request.query.search}} // the value of request.query.search or null if it's not present
+{{val request.query.search or='default' assign='myVar'}} // assign the value of request.query.search or 'default' to myVar
+{{val request.query.search assign='myVar'}} // assign the value of request.query.search to myVar
+
+
+{{val (array 1 2 3) default='123'}} // [1, 2, 3]
+{{val 'value for myVar' assign='myVar'}}{{myVar}} // value for myVar
+{{val null or='other value for myVar' assign='myVar'}}{{myVar}} // other value for myVar
+{{val 10 assign='myVar'}}{{#lt myVar 20}}Less Than{{else}}More Than{{/lt}} // Less Than
+```
+
+{% endraw %}
+
 ## XPath helpers
 
 Additionally some helpers are available for working with JSON and XML.
@@ -718,6 +742,75 @@ Providing no parameters will result in an empty array.
 ```
 
 {% endraw %}
+
+## Array add & remove helpers
+The `arrayAdd` and `arrayRemove` helpers can be used to add or remove elements from an array based on a position value
+or the `start` or `end` keywords. If no position is specified, the element will be added or removed from the end of the 
+array.
+
+{% raw %}
+
+```handlebars
+{{arrayAdd (array 1 'three') 2 position=1}} // [1, 2, three]
+{{arrayAdd (array 1 'three') 2 position='start'}} // [2, 1, three]
+{{arrayAdd (array 1 'three') 2 position='end'}} // [1, three, 2]
+{{arrayAdd (array 1 'three') 2}} // [1, three, 2]
+
+{{arrayRemove (array 1 2 'three') position=1}} // [1, three]
+{{arrayRemove (array 1 2 'three') position='start'}} // [2, three]
+{{arrayRemove (array 1 2 'three') position='end'}} // [1, 2]
+{{arrayRemove (array 1 2 'three')}} // [1, 2]
+```
+
+{% endraw %}
+
+## arrayJoin helper
+
+The `arrayJoin` helper will concatenate the values passed to it with the separator specified:
+
+{% raw %}
+
+```handlebars
+{{arrayJoin ',' (array 'One' 'Two' 'Three')}} // One,Two,Three
+{{arrayJoin ' - ' 'a' 'b' 'c'}} // a - b - c
+{{arrayJoin ', ' (range 1 5)}} // 1, 2, 3, 4, 5
+{{arrayJoin (pickRandom ':') (array 'One' 'Two' 'Three')}} // One:Two:Three
+{{arrayJoin '' (array 'W' 'i' 'r' 'e' 'M' 'o' 'c' 'k' ' ' 'R' 'o' 'c' 'k' 's')}} // WireMock Rocks
+```
+
+{% endraw %}
+
+You can also specify a `prefix` and `suffix` to be added to the start and end of the result:
+
+{% raw %}
+
+```handlebars
+{{arrayJoin ',' (array 'One' 'Two' 'Three') prefix='[' suffix=']'}} // [One,Two,Three]
+```
+
+{% endraw %}
+
+The `arrayJoin` helper can also be used as a block helper:
+
+{% raw %}
+
+```handlebars
+{{#parseJson 'myThings'}}
+[
+  { "id": 1, "name": "One" },
+  { "id": 2, "name": "Two" },
+  { "id": 3, "name": "Three" }
+]
+{{/parseJson}}
+[{{#arrayJoin ',' myThings as |item|}}
+{
+"name{{item.id}}": "{{item.name}}"
+}
+{{/arrayJoin}}] // [{ "name1": "One" }, { "name2": "Two" }, { "name3": "Three" }]
+```
+
+{% endraw %}
+
 
 ## Contains helper
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR documents the new `arrayAdd`, `arrayRemove`, `arrayJoin` and `val` helpers along with the new `start()` and `stop()` extension lifecycle methods

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
