### PR TITLE
wiremock-grpc-extension for test scope only

### DIFF
--- a/_docs/grpc.md
+++ b/_docs/grpc.md
@@ -32,7 +32,7 @@ Add the extension JAR dependency to your project:
 Gradle:
 
 ```gradle
-implementation 'org.wiremock:wiremock-grpc-extension:{{ site.grpc_extension_version }}'
+testImplementation 'org.wiremock:wiremock-grpc-extension:{{ site.grpc_extension_version }}'
 ```
 
 Maven:
@@ -42,6 +42,7 @@ Maven:
     <groupId>org.wiremock</groupId>
     <artifactId>wiremock-grpc-extension</artifactId>
     <version>{{ site.grpc_extension_version }}</version>
+    <scope>test</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
same as demonstrated
https://github.com/wiremock/wiremock-grpc-demos/blob/main/java/build.gradle

keeping it in implementation tree can cause issues with grpc server

## References

- https://github.com/wiremock/wiremock-grpc-demos/blob/main/java/build.gradle

## Submitter checklist

- [ ] The PR request is well described and justified, including the body and the references
- [ ] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [ ] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
