### PR TITLE
Document `ignoreOrderOfSameNode` parameter for `equalToXml` matcher

### DIFF
--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -988,8 +988,8 @@ The full list of comparison types used by default is as follows:
 `ATTR_NAME_LOOKUP`
 
 #### Same child nodes with different content
-By default WireMock takes into account an order of identical child nodes. Meaning if actual request has different order of same node on same level than stub it won't be matched. 
-This can be changed by passing additional argument to the `equalToXml` method
+By default, WireMock takes into account an order of identical child nodes. Meaning if actual request has different order of same node on same level than stub it won't be matched.
+As of WireMock version `3.7.0`, this can be changed by passing additional argument to the `equalToXml` method
 
 Java:
 
@@ -1004,7 +1004,7 @@ Java:
   "request": {
     ...
     "bodyPatterns" : [ {
-      "equalToXml" : "<thing>Hello</thing>",
+      "equalToXml" : "<body><entry>1</entry><entry>2</entry></body>",
       "ignoreOrderOfSameNode": true
     } ]
     ...

--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -987,6 +987,46 @@ The full list of comparison types used by default is as follows:
 `CHILD_LOOKUP`
 `ATTR_NAME_LOOKUP`
 
+#### Same child nodes with different content
+By default WireMock takes into account an order of identical child nodes. Meaning if actual request has different order of same node on same level than stub it won't be matched. 
+This can be changed by passing additional argument to the `equalToXml` method
+
+Java:
+
+```java
+    .withRequestBody(equalToXml("<body>" +
+            "   <entry>1</entry>" +
+            "   <entry>2</entry>" +
+            "</body>",false,true))
+```
+```json
+{
+  "request": {
+    ...
+    "bodyPatterns" : [ {
+      "equalToXml" : "<thing>Hello</thing>",
+      "ignoreOrderOfSameNode": true
+    } ]
+    ...
+  },
+  ...
+}
+```
+This will make sure that stub above matches both of following requests:
+```xml
+<body>
+    <entry>2</entry>
+    <entry>1</entry>
+</body>
+```
+and 
+```xml
+<body>
+    <entry>1</entry>
+    <entry>2</entry>
+</body>
+```
+If third argument is passed as `false` then first xml will not match the stub
 ### XPath
 
 Deems a match if the attribute value is valid XML and matches the XPath expression supplied. An XML document will be considered to match if any elements are returned by the XPath evaluation. WireMock delegates to Java's in-built XPath engine (via XMLUnit), therefore up to (at least) Java 8 it supports XPath version 1.0.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References
main pr: https://github.com/wiremock/wiremock/pull/2747

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
