### PR TITLE
3 7 0 release updates

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -177,6 +177,16 @@ The request journal records requests received by WireMock. It is required by the
 .maxRequestJournalEntries(Optional.of(100))
 ```
 
+## Template Cache
+
+When response templating is enabled, compiled template fragments are cached to improve performance.  This setting allows
+you to configure the maximum number of entries to allow in the cache.  As of WireMock `3.7.0`, this defaults to 1000 
+cache entries.  Before WireMock `3.7.0` the default was unlimited
+
+```java
+.withMaxTemplateCacheEntries(100)
+```
+
 ## Notification (logging)
 
 WireMock wraps all logging in its own `Notifier` interface. It ships with no-op, Slf4j and console (stdout) implementations.

--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -125,6 +125,9 @@ HTTP/2 can be disabled separately for plain text (HTTP) and TLS (HTTPS):
 
 // Send the Host header in the original request onwards to the system being proxied to
 .preserveHostHeader(false)
+    
+// As of WireMock `3.7.0`, when in proxy mode, this option will transfer the original `User-Agent` header from the client to the proxied service.
+.preserveUserAgentProxyHeader(true) 
 
  // Override the Host header sent when reverse proxying to another system (this and the previous parameter are mutually exclusive)
 .proxyHostHeader("my.otherdomain.com")

--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -92,6 +92,9 @@ option is not present, the Host header value is deducted from the proxy
 URL. This option is only available if the `--proxy-all` option is
 specified.
 
+`--preserve-user-agent-proxy-header`: As of WireMock `3.7.0`, when in proxy mode, this option will transfer the 
+original `User-Agent` header from the client to the proxied service.
+
 `--proxy-via`: When proxying requests (either by using --proxy-all or by
 creating stub mappings that proxy to other hosts), route via another
 proxy server (useful when inside a corporate network that only permits

--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -167,7 +167,8 @@ com.mycorp.HeaderTransformer,com.mycorp.BodyTransformer. See [Extending WireMock
 
 `--local-response-templating`: Enable rendering of response definitions using Handlebars templates for specific stub mappings.
 
-`--max-template-cache-entries`: Set the maximum number of compiled template fragments to cache. Only has any effect when response templating is enabled. Defaults to no limit.
+`--max-template-cache-entries`: Set the maximum number of compiled template fragments to cache. Only has any effect when response templating is enabled. As of WireMock `3.7.0`, this defaults to 1000
+cache entries.  Before WireMock `3.7.0` the default was unlimited.
 
 `--use-chunked-encoding`: Set the policy for sending responses with `Transfer-Encoding: chunked`. Valid values are `always`, `never` and `body_file`.
 The last of these will cause chunked encoding to be used only when a stub defines its response body from a file.

--- a/_docs/webhooks-and-callbacks.md
+++ b/_docs/webhooks-and-callbacks.md
@@ -276,6 +276,61 @@ JSON:
 }
 ```
 
+## Observing webhook events
+As of WireMock `3.7.0`, successful webhook requests and responses are logged as Sub Events in the request log.  Any 
+errors that happen as part of the webhook request (not able to contact the target site or error in the handlebars
+template for example) are logged as error Sub Events in the request log. An example of a successful request/response
+webhook Sub Event:
+
+```json
+{
+    "subEvents": [
+        {
+          "type": "WEBHOOK_REQUEST",
+          "timeOffsetNanos": 0,
+          "data": {
+            "url": "/2865e463-1f98-4899-8837-90b89364a5dc",
+            "absoluteUrl": "https://example.com/2865e463-1f98-4899-8837-90b89364a5dc",
+            "method": "POST",
+            "headers": {
+              "Content-Type": "application/json",
+              "Accept": "application/json"
+            },
+            "browserProxyRequest": false,
+            "loggedDate": 1719826613928,
+            "bodyAsBase64": "eyJvbGRTdGF0ZSI6IHt9LCAibmV3U3RhdGUiOiB7fX0=",
+            "body": "{\"oldState\": {}, \"newState\": {}}",
+            "scheme": "https",
+            "host": "example.com",
+            "port": 443,
+            "loggedDateString": "2024-07-01T09:36:53.928Z",
+            "queryParams": {},
+            "formParams": {}
+          }
+        },
+        {
+          "type": "WEBHOOK_RESPONSE",
+          "timeOffsetNanos": 0,
+          "data": {
+            "status": 200,
+            "headers": {
+              "Transfer-Encoding": "chunked",
+              "X-Token-Id": "2865e463-1f98-4899-8837-90b89364a5dc",
+              "Cache-Control": "no-cache, private",
+              "Server": "nginx",
+              "X-Request-Id": "f530c738-bc00-48f2-8382-2394c25a32c6",
+              "Vary": "Accept-Encoding",
+              "Date": "Mon, 01 Jul 2024 09:36:54 GMT",
+              "Content-Type": "text/html; charset=UTF-8"
+            },
+            "bodyAsBase64": "",
+            "body": ""
+          }
+        }
+      ]
+}
+```
+
 ## Extending webhooks
 
 Webhook behaviour can be further customised in code via an extension point.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR updates the docs with the outstanding `3.7.0` updates:

* Adds the max template cache entry size default
* Info on the new webhook sub event infomation
* Adds the new --preserve-user-agent-proxy-header config options

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
