### PR TITLE
Add the numberFormat helper docs

### DIFF
--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -685,8 +685,115 @@ Likewise decimals can be produced with or without bounds:
 {{randomDecimal upper=12.5}}
 {{randomDecimal lower=-24.01}}
 ```
-
 {% endraw %}
+
+## Formatting numbers
+
+The `numberFormat` helper allows you to specify how numbers are printed. It supports
+a number of predefined formats, custom format strings and various other options
+including rounding mode, decimal places and locale.
+
+### Predefined formats
+`numberFormat` supports the following predefined formats:
+
+* `integer`
+* `currency`
+* `percent`
+
+Predefined formats can be affected by locale, so it's usually a good idea to explicitly
+specify this.
+
+For example, to format a decimal number as currency, specifically British pounds:
+
+{% raw %}
+```handlebars
+{{{numberFormat 123.4567 'currency' 'en_GB'}}}
+```
+{% endraw %}
+
+Output: `£123.46`.
+
+Alternatively, if we wanted to output the number as a percentage:
+
+{% raw %}
+```handlebars
+{{{numberFormat 123.4567 'percent' 'en_GB'}}}
+```
+{% endraw %}
+
+Output: `12,346%`.
+
+### Custom format string
+For maximum control over the number format you can specify a format string:
+
+{% raw %}
+```handlebars
+{{{numberFormat 123.4567 '###.000000' 'en_GB'}}}
+```
+{% endraw %}
+
+Output: `123.456700`.
+
+See the [Java DecimalFormat documentation](https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html)
+for details on how to use format strings.
+
+
+### Configuring number of digits
+Separate from the format parameter, the number of digits before and after the
+decimal place can be bounded using one or more of four parameters:
+`maximumFractionDigits`, `minimumFractionDigits`, `maximumIntegerDigits`, `minimumIntegerDigits`.
+
+{% raw %}
+```handlebars
+{{{numberFormat 1234.567 maximumIntegerDigits=3 minimumFractionDigits=6}}}
+```
+{% endraw %}
+
+Output: `234.567000`.
+
+
+### Disabling grouping
+By default `numberFormat` will insert commas, periods etc. per the locale between
+groups of digits e.g. `1,234.5`.
+
+This behaviour can be disabled with `groupingUsed`.
+
+{% raw %}
+```handlebars
+{{{numberFormat 12345.678 groupingUsed=false}}}
+```
+{% endraw %}
+
+Output: `12345.678`.
+
+
+### Rounding mode
+The `roundingMode` parameter affects how numbers will be rounded up or down when
+it's necessary to do so.
+
+For instance, to always round down:
+
+{% raw %}
+```handlebars
+{{{numberFormat 1.239 roundingMode='down' maximumFractionDigits=2}}}
+```
+{% endraw %}
+
+Output: `1.23`.
+
+Available rounding modes are:
+
+* `up`
+* `down`
+* `half_up`
+* `half_down`
+* `half_even`
+* `ceiling`
+* `floor`.
+
+See the [Java RoundingMode documentation](https://docs.oracle.com/javase/8/docs/api/java/math/RoundingMode.html)
+for the exact meaning of each of these.
+
 
 ## Fake data helpers
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR adds the `numberFormat` helper docs to the wiremock.org site

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
