### PR TITLE
Update AssertJ version

### DIFF
--- a/_docs/quickstart/java-junit.md
+++ b/_docs/quickstart/java-junit.md
@@ -42,7 +42,7 @@ like [Apache HttpClient](https://hc.apache.org/httpcomponents-client-5.2.x/#).
 <dependency>
     <groupId>org.assertj</groupId>
     <artifactId>assertj-core</artifactId>
-    <version>3.24.2</version>
+    <version>3.26.3</version>
     <scope>test</scope>
 </dependency>
 ```


### PR DESCRIPTION
Thanks a lot for advertising AssertJ in your docs 🙂 

As AssertJ 3.24.2 is over one year old, I updated the example to 3.26.3, the latest released version.