### PR TITLE
linking to Wiremock Spring Boot in WireMock organization

### DIFF
--- a/_docs/solutions/spring-boot.md
+++ b/_docs/solutions/spring-boot.md
@@ -15,7 +15,7 @@ logo: /images/logos/technology/spring.svg
 
 ## WireMock Spring Boot
 
-[WireMock Spring Boot](https://github.com/maciejwalkowiak/wiremock-spring-boot) 
+[WireMock Spring Boot](https://github.com/wiremock/wiremock-spring-boot)
 simplifies testing HTTP clients in Spring Boot & Junit 5 based integration tests.
 It includes fully declarative WireMock setup,
 supports multiple `WireMockServer` instances,
@@ -26,29 +26,23 @@ Example:
 
 ```java
 @SpringBootTest
-@EnableWireMock({
-    @ConfigureWireMock(name = "user-service", property = "user-client.url")
-})
-class TodoControllerTests {
+@EnableWireMock
+class DefaultInstanceTest {
 
-    @InjectWireMock("user-service")
-    private WireMockServer wiremock;
-    
-    @Autowired
-    private Environment env;
+    @Value("${wiremock.server.baseUrl}")
+    private String wiremockUrl;
 
     @Test
-    void aTest() {
-        // returns a URL to WireMockServer instance
-        env.getProperty("user-client.url"); 
-        wiremock.stubFor(get("/todolist").willReturn(aResponse()
-                .withHeader("Content-Type", "application/json")
-                .withBody("""
-                        [
-                            { "id": 1, "userId": 1, "title": "my todo" },
-                        ]
-                        """)
-        ));
+    void returnsTodos() {
+        WireMock.stubFor(get("/ping")
+            .willReturn(aResponse()
+                .withStatus(200)));
+
+        RestAssured
+        .when()
+            .get(this.wiremockUrl + "/ping")
+        .then()
+            .statusCode(200);
     }
 }
 ```

--- a/external-resources/index.html
+++ b/external-resources/index.html
@@ -75,7 +75,7 @@ description: Extensions, integrations, blog posts and videos about WireMock from
 
     <p><strong>Zero-config, fully declarative Spring Boot integration with WireMock.</strong><br/>
     WireMock Spring Boot drastically simplifies testing HTTP clients in Spring Boot & Junit 5 based integration tests. </p>
-    <a href="https://github.com/maciejwalkowiak/wiremock-spring-boot">https://github.com/maciejwalkowiak/wiremock-spring-boot</a>
+    <a href="https://github.com/wiremock/wiremock-spring-boot">https://github.com/wiremock/wiremock-spring-boot</a>
 
     <p><strong>JSON Web Token Request Matching</strong><br/>
     An extension for matching requests based on the contents of JSON web tokens</p>


### PR DESCRIPTION
Now that it has moved.

## References

- https://github.com/wiremock/wiremock-spring-boot

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
