### PR TITLE
Remove the old banner notification as it references an old event

### DIFF
--- a/assets/js/notifications.js
+++ b/assets/js/notifications.js
@@ -1,21 +1,7 @@
 var wiremock_notification_shown = localStorage.getItem(
   "wiremock_notification_shown",
 );
-var notifications = [
-  {
-  content: {
-    title:
-    "Learn the basics of our new stateful mocking at WireMock Live on August 22" +
-    "<a href='https://info.wiremock.io/wiremock-live-demos-24-08?utm_source=oss-wmlive&utm_medium=oss-wmlive&utm_campaign=oss-wmlive&utm_id=oss-wmlive&utm_term=oss-wmlive' target='_blank'>Register now.</a>",
-  },
-  layout: {
-    style: "wiremock_notification_with_link",
-    position: "top",
-    className: "info",
-    autoHide: false,
-  },
-  },
-];
+var notifications = [];
 
 if (wiremock_notification_shown == null) {
   localStorage.setItem("wiremock_notification_shown", true);


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Remove the old banner till we have something new to put up there.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
