### PR TITLE
Update junit-jupiter.md. to reflect v3 method signature

### DIFF
--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -108,7 +108,7 @@ public class ProgrammaticWireMockTest {
     static WireMockExtension wm2 = WireMockExtension.newInstance()
             .options(wireMockConfig()
                      .dynamicPort()
-                     .extensions(new ResponseTemplateTransformer(true)))
+                     .extensions(new ResponseTemplateTransformer(templateEngine, global, files, templateModelDataProviders)))
             .build();
 
     @Test

--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -108,7 +108,13 @@ public class ProgrammaticWireMockTest {
     static WireMockExtension wm2 = WireMockExtension.newInstance()
             .options(wireMockConfig()
                      .dynamicPort()
-                     .extensions(new ResponseTemplateTransformer(templateEngine, global, files, templateModelDataProviders)))
+                     .extensions(new ResponseTemplateTransformer(
+                          getTemplateEngine(),
+                          options.getResponseTemplatingGlobal(),
+                          getFiles(),
+                          templateModelProviders
+                        )
+                     )
             .build();
 
     @Test


### PR DESCRIPTION
Method Signature for ResponseTemplateTransformer has changed in v3. 
I've made changes in the document to reflect the same.

The following snippet is the actual constructor method in v3.10.0

```java
public ResponseTemplateTransformer(TemplateEngine templateEngine, boolean global, FileSource files, List<TemplateModelDataProviderExtension> templateModelDataProviders) {
        this.templateEngine = templateEngine;
        this.global = global;
        this.files = files;
        this.templateModelDataProviders = templateModelDataProviders;
    }
```