### PR TITLE
Add redirect for custom request matching documentation

### DIFF
--- a/_docs/extensibility/custom-request-matching.md
+++ b/_docs/extensibility/custom-request-matching.md
@@ -3,6 +3,8 @@ layout: docs
 title: Custom Request Matching
 meta_title: Adding custom request matchers
 description: Adding custom request matchers via extensions
+redirect_from:
+  - "/docs/extensibility/custom-matching/"
 ---
 
 If WireMock's standard set of request matching strategies isn't


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Add a page redirect from `/docs/extensibility/custom-matching/` to the new custom request matching page

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
