### PR TITLE
Update the github action for `upload-pages-artifact`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
 #          enforce_https: false
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -76,7 +76,7 @@ jobs:
 #          enforce_https: false
       - name: Upload artifact
         # Automatically uploads an artifact from the './_site' directory by default
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   # Deployment job
   deploy:


### PR DESCRIPTION
This action depends on an old version of `actions/upload-artifact` which is no longer supported by github

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
