### PR TITLE
Add version information to the new attributes added in WireMock 3.12.0

### DIFF
--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -1170,8 +1170,8 @@ If third argument is passed as `false` then first xml will not match the stub
 
 #### Namespace awareness
 
-To configure how [XML namespaces](https://www.w3schools.com/xml/xml_namespaces.asp) are handled, the
-`namespaceAwareness` property can be set.
+To configure how [XML namespaces](https://www.w3schools.com/xml/xml_namespaces.asp) are handled, as of WireMock 
+`3.12.0`, the `namespaceAwareness` property can be set.
 
 {% codetabs %}
 

--- a/_docs/response-templating.md
+++ b/_docs/response-templating.md
@@ -1083,8 +1083,8 @@ Like the `jsonArrayAdd` helper, the second object can be provided as a block:
 {% endraw %}
 
 ### Removing attributes
-The `jsonMerge` helper has an optional `removeNulls` parameter which, when set to true will remove any attributes from the resulting JSON that
-have null values in the second JSON document.
+Starting with WireMock version `3.12.0`, the `jsonMerge` helper has an optional `removeNulls` parameter which, when 
+set to true will remove any attributes from the resulting JSON that have null values in the second JSON document.
 
 So for instance, given the following template:
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Add version information to the new attributes added in WireMock 3.12.0

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
