### PR TITLE
Document the new option to configure the webhook threadpool size

### DIFF
--- a/_docs/configuration.md
+++ b/_docs/configuration.md
@@ -318,3 +318,15 @@ If you want to increase the proxying performance of wiremock you can enable Conn
 .disableConnectionReuse(true)
 ```
 
+## Webhook configuration
+
+The default webhook thread pool size is 10.  This is more than enough for normal mocking with callbacks but if you are
+running performance tests using WireMock with callbacks, you might need to tweak the size of the threadpool used to 
+process webhook requests. 
+
+```java
+// The number of threads created for processing webhook requests. Defaults to 10
+.withWebhookThreadPoolSize(100)
+
+```
+

--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -223,6 +223,8 @@ Note: introduced in [3.0.0-beta-8](https://github.com/wiremock/wiremock/releases
 
 `--version` : Prints wiremock version information and exits
 
+`--webhook-threadpool-size`: The number of threads created for processing webhook requests. Defaults to 10
+
 
 `--help`: Show command line help
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->


## References

- To be merged when this is released - https://github.com/wiremock/wiremock/pull/3009

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
