### PR TITLE
Document new resetOnEachTest method in the WireMockExtension.

### DIFF
--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -137,7 +137,7 @@ public class ProgrammaticWireMockTest {
 ### Static vs. instance
 
 In the above example, as with the declarative form, each WireMock server will be started before the first test method in the test class and stopped after the
-last test method has completed, with a call to reset before each test method.
+last test method has completed, and by default, with a call to reset before each test method.
 
 However, if the extension fields are declared at the instance scope (without the `static` modifier) each WireMock server will
 be created and started before each test method and stopped after the end of the test method.
@@ -170,6 +170,13 @@ public class AutomaticStaticDslConfigTest {
     }
 }
 ```
+
+## Resetting before each test method
+By default WireMock will be reset before each tests method.  This will reset the stubs and any requests that have been 
+made.  
+
+Most of the time this is the desired behaviour but this behavior can be changed by calling `.resetOnEachTest(false)` on
+the extension builder when using the programmatic form.
 
 ## Unmatched request behaviour
 

--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -176,7 +176,7 @@ By default WireMock will be reset before each tests method.  This will reset the
 made.  
 
 Most of the time this is the desired behaviour but this behavior can be changed by calling `.resetOnEachTest(false)` on
-the extension builder when using the programmatic form.
+the extension builder when using the programmatic form.  This option is available as of WireMock version `3.13.0`
 
 ## Unmatched request behaviour
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

- To be merged when this feature is released - https://github.com/wiremock/wiremock/pull/3010

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
