### PR TITLE
Document the request client IP matcher

### DIFF
--- a/_docs/request-matching.md
+++ b/_docs/request-matching.md
@@ -42,6 +42,7 @@ stubFor(any(urlPathEqualTo("/everything"))
   		.withHeader("Content-Type", containing("charset"))
   		.withBody(equalToJson("{}"))
   )
+  .withClientIp(equalTo("127.0.0.1"))
   .willReturn(aResponse()));
 ```
 {% endcodetab %}
@@ -96,6 +97,9 @@ stubFor(any(urlPathEqualTo("/everything"))
         "basicAuthCredentials": {
             "username": "jeff@example.com",
             "password": "jeffteenjefftyjeff"
+        },
+        "clientIp": {
+            "equalTo": "127.0.0.1"
         }
     },
     "response": {


### PR DESCRIPTION
Includes an example for the native client IP matcher in the section where all attributes are shown both in DSL and JSON formats.

## References

* https://github.com/wiremock/wiremock/pull/3014

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
