### PR TITLE
Document finding/removing unmatched stub mappings

### DIFF
--- a/_docs/stubbing.md
+++ b/_docs/stubbing.md
@@ -595,6 +595,14 @@ To fetch them via the HTTP API send a `GET` to `http://<host>:<port>/__admin/map
 Optionally limit and offset parameters can be specified to constrain the set returned e.g.
 `GET http://localhost:8080/__admin/mappings?limit=10&offset=50`
 
+## Unmatched stub mappings
+
+Stub mappings that haven't matched any requests in the [the journal](../verifying#querying-the-request-journal) can be retrieved in Java by calling `WireMock.findUnmatchedStubs()`.
+
+This can be useful when combined with [record and playback](../record-playback/) to prune unused stub mappings.
+
+Via the HTTP API, send a `GET` or `DELETE` request to `http://<host>:<port>/__admin/mappings/unmatched` to fetch or remove them, respectively. Note that a `DELETE` request will not remove any associated body files under the `__files` directory.
+
 ## Getting a single stub mapping by ID
 
 A single stub mapping can be retrieved by ID in Java by calling `WireMock.getSingleStubMapping(id)` where `id` is the

--- a/assets/js/wiremock-admin-api.json
+++ b/assets/js/wiremock-admin-api.json
@@ -399,6 +399,85 @@
         }
       }
     },
+    "/__admin/mappings/unmatched": {
+      "get": {
+        "operationId": "findUnmatchedStubMappings",
+        "summary": "Find unmatched stub mappings",
+        "description": "Find stub mappings that haven't matched any requests in the journal",
+        "tags": [
+          "Stub Mappings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Unmatched stub mappings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/stub-mappings"
+                },
+                "example": {
+                  "meta": {
+                    "total": 2
+                  },
+                  "mappings": [
+                    {
+                      "id": "76ada7b0-49ae-4229-91c4-396a36f18e09",
+                      "uuid": "76ada7b0-49ae-4229-91c4-396a36f18e09",
+                      "request": {
+                        "method": "GET",
+                        "url": "/search?q=things",
+                        "headers": {
+                          "Accept": {
+                            "equalTo": "application/json"
+                          }
+                        }
+                      },
+                      "response": {
+                        "status": 200,
+                        "jsonBody": [
+                          "thing1",
+                          "thing2"
+                        ],
+                        "headers": {
+                          "Content-Type": "application/json"
+                        }
+                      }
+                    },
+                    {
+                      "request": {
+                        "method": "POST",
+                        "urlPath": "/some/things",
+                        "bodyPatterns": [
+                          {
+                            "equalToXml": "<stuff />"
+                          }
+                        ]
+                      },
+                      "response": {
+                        "status": 201
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "removeUnmatchedStubMappings",
+        "summary": "Remove unmatched stub mappings",
+        "description": "Remove stub mappings that haven't matched any requests in the journal",
+        "tags": [
+          "Stub Mappings"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/__admin/requests": {
       "get": {
         "operationId": "getAllRequestsInJournal",

--- a/swagger/wiremock-admin-api.yaml
+++ b/swagger/wiremock-admin-api.yaml
@@ -211,6 +211,32 @@ paths:
         '200':
           description: 'The stub mappings were successfully removed'
 
+  /__admin/mappings/unmatched:
+    get:
+      operationId: findUnmatchedStubMappings
+      summary: Find unmatched stub mappings
+      description: Find stub mappings that haven't matched any requests in the journal
+      tags:
+        - Stub Mappings
+      responses:
+        '200':
+          description: Unmatched stub mappings
+          content:
+            application/json:
+              schema:
+                $ref: 'schemas/stub-mappings.yaml'
+              example:
+                $ref: 'examples/stub-mappings.yaml'
+    delete:
+      operationId: removeUnmatchedStubMappings
+      summary: Remove unmatched stub mappings
+      description: Remove stub mappings that haven't matched any requests in the journal
+      tags:
+        - Stub Mappings
+      responses:
+        '200':
+          description: OK
+
   /__admin/requests:
     get:
       operationId: getAllRequestsInJournal


### PR DESCRIPTION
## References

This documents the functionality in https://github.com/wiremock/wiremock/pull/2991, as requested by @leeturner.

I wasn't able to get the dev environment running because of multiple different errors. For example, `yarn` failed to install or compile `node-sass` for some reason:
```console
$ yarn
yarn install v1.22.22
[1/5] Validating package.json...
[2/5] Resolving packages...
warning @redocly/cli > glob@7.2.3: Glob versions prior to v9 are no longer supported
[3/5] Fetching packages...
[4/5] Linking dependencies...
warning " > redoc@2.1.5" has unmet peer dependency "core-js@^3.1.4".
warning " > redoc@2.1.5" has unmet peer dependency "mobx@^6.0.4".
warning " > redoc@2.1.5" has unmet peer dependency "react@^16.8.4 || ^17.0.0 || ^18.0.0".
warning " > redoc@2.1.5" has unmet peer dependency "react-dom@^16.8.4 || ^17.0.0 || ^18.0.0".
warning " > redoc@2.1.5" has unmet peer dependency "styled-components@^4.1.1 || ^5.1.1 || ^6.0.5".
warning "redoc > @cfaester/enzyme-adapter-react-18@0.8.0" has unmet peer dependency "enzyme@^3.11.0".
warning "redoc > @cfaester/enzyme-adapter-react-18@0.8.0" has unmet peer dependency "react@>=18".
warning "redoc > @cfaester/enzyme-adapter-react-18@0.8.0" has unmet peer dependency "react-dom@>=18".
warning "redoc > mobx-react@9.1.1" has unmet peer dependency "mobx@^6.9.0".
warning "redoc > mobx-react@9.1.1" has unmet peer dependency "react@^16.8.0 || ^17 || ^18".
warning "redoc > react-tabs@6.0.2" has unmet peer dependency "react@^18.0.0".
warning "redoc > @cfaester/enzyme-adapter-react-18 > react-shallow-renderer@16.15.0" has unmet peer dependency "react@^16.0.0 || ^17.0.0 || ^18.0.0".
warning "redoc > mobx-react > mobx-react-lite@4.0.7" has unmet peer dependency "mobx@^6.9.0".
warning "redoc > mobx-react > mobx-react-lite@4.0.7" has unmet peer dependency "react@^16.8.0 || ^17 || ^18".
warning "redoc > mobx-react > mobx-react-lite > use-sync-external-store@1.2.2" has unmet peer dependency "react@^16.8.0 || ^17.0.0 || ^18.0.0".
warning "@redocly/cli > @redocly/respect-core > better-ajv-errors@1.2.0" has unmet peer dependency "ajv@4.11.8 - 8".
[5/5] Building fresh packages...
[1/4] ⡀ node-sass
[2/4] ⡀ core-js
[-/4] ⡀ waiting...
error /home/masonm/src/wiremock.org/node_modules/node-sass: Command failed.
Exit code: 1
Command: node scripts/build.js
Arguments:
Directory: /home/masonm/src/wiremock.org/node_modules/node-sass
Output:
Binary found at /home/masonm/src/wiremock.org/node_modules/node-sass/vendor/linux-x64-127/binding.node
Testing binary
Binary has a problem: Error: /home/masonm/src/wiremock.org/node_modules/node-sass/vendor/linux-x64-127/binding.node: file too short
    at Object..node (node:internal/modules/cjs/loader:1734:18)
    at Module.load (node:internal/modules/cjs/loader:1318:32)
    at Function._load (node:internal/modules/cjs/loader:1128:12)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:219:24)
    at Module.require (node:internal/modules/cjs/loader:1340:12)
    at require (node:internal/modules/helpers:138:16)
    at module.exports (/home/masonm/src/wiremock.org/node_modules/node-sass/lib/binding.js:19:10)
    at Object.<anonymous> (/home/masonm/src/wiremock.org/node_modules/node-sass/lib/index.js:13:35)
    at Module._compile (node:internal/modules/cjs/loader:1565:14) {
  code: 'ERR_DLOPEN_FAILED'
}
Building the binary locally
Building: /home/masonm/.volta/tools/image/node/22.12.0/bin/node /home/masonm/src/wiremock.org/node_modules/node-gyp/bin/node-gyp.js rebuild --verbose --libsass_ext= --libsass_cflags= --libsass_ldflags= --libsass_library=
<SNIP THOUSANDS OF LINES OF COMPILER ERRORS>
```

Also, Jekyll gave a different error:
```console
$ bundle exec jekyll serve --config '_config.yml'

Configuration file: /home/masonm/src/wiremock.org/_config.yml
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
            Source: /home/masonm/src/wiremock.org
       Destination: /home/masonm/src/wiremock.org/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
       Jekyll Feed: Generating feed for posts
                    ------------------------------------------------
      Jekyll 4.3.2   Please append `--trace` to the `serve` command
                     for any additional information or backtrace.
                    ------------------------------------------------
/home/masonm/src/wiremock.org/vendor/bundle/ruby/3.2.0/gems/json-1.8.6/lib/json/common.rb:155:in `initialize': wrong number of arguments (given 2, expected 1) (ArgumentError)

    Parser.new(source, opts).parse
               ^^^^^^^^^^^^
        from /home/masonm/src/wiremock.org/vendor/bundle/ruby/3.2.0/gems/json-1.8.6/lib/json/common.rb:155:in `new'
        from /home/masonm/src/wiremock.org/vendor/bundle/ruby/3.2.0/gems/json-1.8.6/lib/json/common.rb:155:in `parse'
```

I'm guessing the Jekyll error is because I'm on Ruby 3.2, and I don't have Ruby 2.7 installed. If there's a Docker container for this, I can try that, but I really don't want to install more stuff on my host machine (especially not end-of-life Ruby versions).

<!-- Please describe your pull request here. -->


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [X] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
