### PR TITLE
Update graphql wiremock cloud callout

### DIFF
--- a/_docs/solutions/graphql.md
+++ b/_docs/solutions/graphql.md
@@ -11,7 +11,7 @@ redirect_from:
 hide-disclaimer: true
 ---
 
-<div class="cloud-callout"><a href="https://www.wiremock.io?utm_source=oss-docs&utm_medium=oss-docs&utm_campaign=cloud-callouts-solutiongraphql&utm_id=cloud-callouts&utm_term=cloud-callouts-solutiongraphql" target="_BLANK">Centralize and scale your API mocks with WireMock Cloud.</a></div>
+<div class="cloud-callout"><a href="https://www.wiremock.io/post/graphql-mocking-in-wiremock-cloud-beta?utm_source=oss-docs&utm_medium=oss-docs&utm_campaign=cloud-callouts-solutiongraphql&utm_id=cloud-callouts&utm_term=cloud-callouts-solutiongraphql" target="_BLANK">Mock your GraphQL endpoints in WireMock Cloud with instant mock data and federated supergraph</a></div>
 
 ## WireMock Extension
 


### PR DESCRIPTION

Update the graphql callout now we have released graphql mocking in cloud


<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
