### PR TITLE
Document the urlPathTemplate matcher

### DIFF
--- a/swagger/schemas/request-pattern.yaml
+++ b/swagger/schemas/request-pattern.yaml
@@ -29,22 +29,25 @@ properties:
     description: The HTTP request method e.g. GET
   url:
     type: string
-    description: The path and query to match exactly against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified.
+    description: The path and query to match exactly against. Only one of url, urlPattern, urlPath, urlPathPattern or urlPathTemplate may be specified.
   urlPath:
     type: string
-    description: The path to match exactly against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified.
+    description: The path to match exactly against. Only one of url, urlPattern, urlPath, urlPathPattern or urlPathTemplate may be specified.
   urlPathPattern:
     type: string
-    description: The path regex to match against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified.
+    description: The path regex to match against. Only one of url, urlPattern, urlPath, urlPathPattern or urlPathTemplate may be specified.
   urlPattern:
     type: string
-    description: The path and query regex to match against. Only one of url, urlPattern, urlPath or urlPathPattern may be specified.
+    description: The path and query regex to match against. Only one of url, urlPattern, urlPath, urlPathPattern or urlPathTemplate may be specified.
+  urlPathTemplate:
+    type: string
+    description: A Level 1 URI Template as specified in https://datatracker.ietf.org/doc/html/rfc6570. Only one of url, urlPattern, urlPath, urlPathPattern or urlPathTemplate may be specified.
 
   pathParameters:
     type: object
     description: |
       Path parameter patterns to match against in the <key>: { "<predicate>": "<value>" } form. Can only
-      be used when the urlPathPattern URL match type is in use and all keys must be present as variables
+      be used when the urlPathTemplate URL match type is in use and all keys must be present as variables
       in the path template.
     additionalProperties:
       $ref: "content-pattern.yaml"


### PR DESCRIPTION
Documents the existence of the urlPathTemplate matcher in the OpenAPI schema

## References

N/A

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
