### PR TITLE
Add raw tags so the filename-template example displays correctly

### DIFF
--- a/_docs/standalone/java-jar.md
+++ b/_docs/standalone/java-jar.md
@@ -216,7 +216,7 @@ The last of these will cause chunked encoding to be used only when a stub define
 
 `--proxy-pass-through`: Flag used in browser-caching in order to enable or disable pass through unmatched requests to the target indicated by the original requests. By default, this flag is enabled and let the requests pass through.
 
-`--filename-template`: Set filename template in handlebar format. For endpoint: `GET /pets/{id}` using the format: `{{{method}}}-{{{url}}}.json` output will be `get-pets-id.json`. Default format: `{{{method}}}-{{{path}}}-{{{id}}}.json` hence by default template filename will be: `get-pets-id-1.json`.   
+`--filename-template`: Set filename template in handlebar format. For endpoint: `GET /pets/{id}` using the format: `{% raw %}{{{method}}}-{{{url}}}.json{% endraw %}` output will be `get-pets-id.json`. Default format: `{% raw %}{{{method}}}-{{{path}}}-{{{id}}}.json{% endraw %}` hence by default template filename will be: `get-pets-id-1.json`.   
 Note: introduced in [3.0.0-beta-8](https://github.com/wiremock/wiremock/releases/tag/3.0.0-beta-8).
 
 `--timeout` : The default global timeout


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

On the [page](https://wiremock.org/docs/standalone/java-jar/) where we show all the parameters that can be passed to the standalone jar, the examples in `--filename-template` option were not displaying correctly due to the use of `}` in the examples.  This is how it currently renders:

```
--filename-template: Set filename template in handlebar format. For endpoint: GET /pets/{id} using the format: }-}.json output will be get-pets-id.json. Default format: }-}-}.json hence by default template filename will be: get-pets-id-1.json. 
```

This PR adds `raw` tags around the examples to allow them to be rendered as is.

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
