### PR TITLE
chore: Update the python repo link

### DIFF
--- a/_docs/solutions/python.md
+++ b/_docs/solutions/python.md
@@ -23,7 +23,7 @@ that connects to a standalone WireMock server.
 This project is a part of WireMock's GitHub organization.
 
 - [Documentation](https://wiremock.readthedocs.io/en/latest/)
-- [Official Repository](https://github.com/platinummonkey/python-wiremock.git)
+- [Official Repository](https://github.com/wiremock/python-wiremock/)
 
 ## Robot Framework Library
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
The link to the python repo was out of date now it has move into the WireMock OSS org

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
