### PR TITLE
fix: broken link to extending wiremock via service loading

### DIFF
--- a/_docs/junit-jupiter.md
+++ b/_docs/junit-jupiter.md
@@ -81,7 +81,7 @@ public class HttpsFixedPortDeclarativeWireMockTest {
 
 ### Enabling Extension Scanning
 
-When [extending WireMock via service loading](extending-wiremock.md#extension-registration-via-service-loading), it may
+When [extending WireMock via service loading](https://wiremock.org/docs/extending-wiremock/#extension-registration-via-service-loading), it may
 be helpful to have WireMock scan for extensions automatically via the `extensionScanningEnabled` parameter.
 
 ```java


### PR DESCRIPTION
fixes: #373

<!-- Please describe your pull request here. -->

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
