### PR TITLE
fix: Make the static copyright year dynamic.

### DIFF
--- a/src/static/index.html
+++ b/src/static/index.html
@@ -450,11 +450,12 @@ wiremock/wiremock:3.13.2</code></pre>
 </div>
 <footer class="home__footer">
     <div class="page__footer-copyright"><img src="/images/shortLogo.png" class="short-logo">
-        <span class="footer-copyright-description">© 2025</span>
+        <span class="footer-copyright-description">© <span id="copyright-year">2026</span></span>
         <ul class="footer-social-links">
             <li><a href="http://github.com/wiremock" target="_blank"> <img src="/images/githubIcon.svg"> </a></li>
         </ul>
     </div>
 </footer>
+<script>document.getElementById('copyright-year').textContent = String(new Date().getFullYear());</script>
 </body>
 </html>


### PR DESCRIPTION
The year is hardcoded to 2025 on the homepage.  Default to 2026 and make dynamic

<!-- References to relevant GitHub issues and pull requests, esp. upstream and downstream changes -->

## Submitter checklist

- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [ ] If the change against WireMock 2 functionality (incompatible with WireMock 3),
      it is submitted against the [2.x](https://github.com/wiremock/wiremock.org/tree/2.x) branch
- [x] The repository's code style is followed (see the contributing guide)

_Details: [Contributor Guide](https://github.com/wiremock/wiremock.org/blob/main/CONTRIBUTING.md)_
