### PR TITLE
Fix broken Java JUnit 4 quickstart HTTP client example

### DIFF
--- a/src/content/docs/docs/quickstart/java-junit.mdx
+++ b/src/content/docs/docs/quickstart/java-junit.mdx
@@ -86,6 +86,7 @@ public WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructo
 Now you're ready to write a test case like this:
 
 ```java
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -93,7 +94,7 @@ import java.net.http.HttpResponse;
 ...
 
 @Test
-public void exampleTest() {
+public void exampleTest() throws Exception {
     // Setup the WireMock mapping stub for the test
     stubFor(post("/my/resource")
         .withHeader("Content-Type", containing("xml"))
@@ -104,9 +105,10 @@ public void exampleTest() {
     // Setup HTTP POST request (with HTTP Client embedded in Java 11+)
     final HttpClient client = HttpClient.newBuilder().build();
     final HttpRequest request = HttpRequest.newBuilder()
-        .uri(wiremockServer.url("/my/resource"))
+        .uri(URI.create(wireMockRule.url("/my/resource")))
         .header("Content-Type", "text/xml")
-        .POST().build();
+        .POST(HttpRequest.BodyPublishers.noBody())
+        .build();
 
     // Send the request and receive the response
     final HttpResponse<String> response =


### PR DESCRIPTION
## Summary
- fix the Java/JUnit 4 quickstart snippet to use wireMockRule.url(...) instead of the undefined wiremockServer`n- make the Java 11+ HTTP client example compile by using URI.create(...), 	hrows Exception, and HttpRequest.BodyPublishers.noBody()`n
Closes #307.

## Verification
- pnpm build generated /docs/quickstart/java-junit/index.html, then failed in the repo's existing copy-static-homepage build hook with ENOENT while copying src/static/index.html to an invalid C:\C:\... destination
- mvn -q test passed in a throwaway verification project that exercises the corrected JUnit 4 snippet against WireMock 3.13.2