### PR TITLE
docs: clarify JUnit Jupiter imports

### DIFF
--- a/src/content/docs/docs/junit-jupiter.mdx
+++ b/src/content/docs/docs/junit-jupiter.mdx
@@ -18,6 +18,18 @@ WireMock server, defaulting to a random port, HTTP only (no HTTPS).
 To get the running port number, base URL or a DSL instance you can declare a parameter of type `WireMockRuntimeInfo`
 in your test or lifecycle methods.
 
+If you want a copy-paste starting point, `@WireMockTest` and `WireMockRuntimeInfo` are imported from
+`com.github.tomakehurst.wiremock.junit5`:
+
+```java
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+```
+
 ```java
 @WireMockTest
 public class DeclarativeWireMockTest {


### PR DESCRIPTION
## Summary
- add an explicit import block for `@WireMockTest` and `WireMockRuntimeInfo`
- make the first JUnit Jupiter example copy-pasteable
- clarify the package users should import from when following this page

Fixes #304

## Verification
- `pnpm exec astro build` generated `/docs/junit-jupiter/index.html` but still hit the repo's pre-existing Windows `copy-static-homepage` failure with an invalid `C:\C:\...` copy target
- `mvn org.apache.maven.plugins:maven-dependency-plugin:3.8.1:get "-Dartifact=org.wiremock:wiremock:3.13.2"`
- verified `WireMockTest.class` and `WireMockRuntimeInfo.class` exist in `org.wiremock:wiremock:3.13.2`