### PR TITLE
Fix incorrect admin API docs path

### DIFF
--- a/src/content/docs/docs/standalone/admin-api-reference.mdx
+++ b/src/content/docs/docs/standalone/admin-api-reference.mdx
@@ -11,7 +11,7 @@ import CloudCallout from '../../../../components/CloudCallout.astro';
     [**Try WireMock Cloud >**](https://www.wiremock.io?utm_source=oss-docs&utm_medium=oss-docs&utm_campaign=cloud-callouts-adminapi&utm_id=cloud-callouts&utm_term=cloud-callouts-adminapi)
 </CloudCallout>
 
-The WireMock admin API is described in [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md). The spec file plus an instance of Swagger UI can be accessed from a running WireMock instance under `/__admin/docs/`, e.g. `http://localhost:8080/__admin/docs/`.
+The WireMock admin API is described in [OpenAPI 3.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md). The spec file plus an instance of Swagger UI can be accessed from a running WireMock instance under `/__admin/docs`, e.g. `http://localhost:8080/__admin/docs`.
 
 Download the full [OpenAPI description](https://wiremock.org/js/wiremock-admin-api.json) or browse the API docs:
 


### PR DESCRIPTION
## Summary
- remove the trailing slash from the `/__admin/docs` path in the admin API reference
- keep the example URL aligned with the actual WireMock endpoint behavior

Fixes wiremock/wiremock#3332

## Verification
- `pnpm install`
- `pnpm approve-builds --all`
- `pnpm build` (Astro rendered `dist/docs/standalone/admin-api-reference/index.html` with the corrected `/__admin/docs` URL, but the repo's existing Windows `copy-static-homepage` hook still fails with an invalid `C:\C:\...` destination)