### PR TITLE
Clarify WireMock DSL static imports in docs

### DIFF
--- a/src/content/docs/docs/request-matching.mdx
+++ b/src/content/docs/docs/request-matching.mdx
@@ -24,6 +24,12 @@ WireMock enables flexible definition of a mock API by supporting rich matching o
 - Multipart/form-data
 - Client IP (as of WireMock version `3.13.0`)
 
+Most Java examples on this page use static imports from `WireMock`:
+
+```java
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+```
+
 Here's an example showing all attributes being matched using WireMock's in-built match operators. It is also possible to write [custom matching logic](../extending-wiremock/#custom-request-matchers/) if
 you need more precise control:
 

--- a/src/content/docs/docs/stubbing.mdx
+++ b/src/content/docs/docs/stubbing.mdx
@@ -16,6 +16,12 @@ import CloudCallout from '../../../components/CloudCallout.astro';
 A core feature of WireMock API mocking is the ability to return canned HTTP
 responses for requests matching criteria. These are described in detail in [Request Matching](../request-matching/).
 
+Most Java examples on this page use static imports from `WireMock`:
+
+```java
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+```
+
 
 ## Basic stubbing
 


### PR DESCRIPTION
## Summary
- add an explicit WireMock static import snippet to the Java stubbing docs
- add the same import guidance to the request matching docs, where the DSL appears immediately

Closes #9.

## Verification
- pnpm install`n- pnpm approve-builds --all`n- pnpm build rendered dist/docs/stubbing/index.html and dist/docs/request-matching/index.html with the new import snippet
- pnpm build still ends with the repo's pre-existing Windows copy-static-homepage hook failure that tries to copy to C:\C:\...\dist\index.html after the site output is already generated