### PR TITLE
Update quickstart guide to JUnit 5

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -50,7 +50,7 @@ export default defineConfig({
                                 label: 'Getting started',
                                 items: [
                                     { label: 'Overview', slug: 'docs/overview' },
-                                    { label: 'Quick Start API Mocking with Java and JUnit 4', slug: 'docs/quickstart/java-junit' },
+                                    { label: 'Quick Start API Mocking with Java and JUnit 5', slug: 'docs/quickstart/java-junit' },
                                     { label: 'Download and Install', slug: 'docs/download-and-installation' },
                                     { label: 'WireMock Tutorials', slug: 'docs/getting-started' },
                                     { label: 'Frequently Asked Questions', slug: 'docs/faq' },

--- a/src/content/docs/docs/getting-started.md
+++ b/src/content/docs/docs/getting-started.md
@@ -11,7 +11,7 @@ Check out the guidelines below.
 
 At the moment, we provide the following quick starts for beginners:
 
-- [API Mocking with Java and JUnit 4](../quickstart/java-junit/)
+- [API Mocking with Java and JUnit 5](../quickstart/java-junit/)
 - [Downloading and Installing WireMock](../download-and-installation/)
 - [Using WireMock with Jetty 12](../jetty-12/)
 

--- a/src/content/docs/docs/quickstart/java-junit.mdx
+++ b/src/content/docs/docs/quickstart/java-junit.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Quick Start: API Mocking with Java and JUnit 4"
+title: "Quick Start: API Mocking with Java and JUnit 5"
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -12,7 +12,7 @@ import { VERSIONS } from '../../../../config/versions.ts';
     [**Try WireMock Cloud >**](https://www.wiremock.io?utm_source=oss-docs&utm_medium=oss-docs&utm_campaign=cloud-callouts-quickstartjunit&utm_id=cloud-callouts&utm_term=cloud-callouts-quickstartjunit)
 </CloudCallout>
 
-In this guide we will write an API Unit test with WireMock and JUnit 4.
+In this guide we will write an API unit test with WireMock and JUnit 5 Jupiter.
 
 ## Prerequisites
 
@@ -30,6 +30,8 @@ In our test, we will also use AssertJ to verify the responses.
 To send the requests, we will use the embedded HTTP client available in Java 11+.
 If you want to add a Java 1.8 test, you will need to add an external HTTP Client implementation
 like [Apache HttpClient](https://hc.apache.org/httpcomponents-client-5.2.x/#).
+
+This example assumes your project is already configured to run JUnit 5 tests.
 
 <Tabs>
 <TabItem label="Maven">
@@ -62,14 +64,18 @@ testImplementation "org.assertj:assertj-core:3.24.2"`}
 
 
 
-## Add the WireMock rule
+## Add the WireMock extension
 
-WireMock ships with some JUnit rules to manage the server's lifecycle
+WireMock ships with a JUnit Jupiter extension to manage the server's lifecycle
 and setup/tear-down tasks.
 
-To use WireMock's fluent API add the following import:
+To use WireMock's fluent API add the following imports:
 
 ```java
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.Test;
+
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 ```
 
@@ -77,8 +83,9 @@ To automatically start and stop WireMock per-test case, add
 the following to your test class (or a superclass of it):
 
 ```java
-@Rule
-public WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructor defaults to port 8080
+@WireMockTest(httpPort = 8089)
+class ExampleTest {
+}
 ```
 
 ## Write a test
@@ -86,76 +93,86 @@ public WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructo
 Now you're ready to write a test case like this:
 
 ```java
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 ...
 
-@Test
-public void exampleTest() {
-    // Setup the WireMock mapping stub for the test
-    stubFor(post("/my/resource")
-        .withHeader("Content-Type", containing("xml"))
-        .willReturn(ok()
-            .withHeader("Content-Type", "text/xml")
-            .withBody("<response>SUCCESS</response>")));
+@WireMockTest(httpPort = 8089)
+class ExampleTest {
 
-    // Setup HTTP POST request (with HTTP Client embedded in Java 11+)
-    final HttpClient client = HttpClient.newBuilder().build();
-    final HttpRequest request = HttpRequest.newBuilder()
-        .uri(wiremockServer.url("/my/resource"))
-        .header("Content-Type", "text/xml")
-        .POST().build();
+    @Test
+    void exampleTest(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        // Setup the WireMock mapping stub for the test
+        stubFor(post("/my/resource")
+            .withHeader("Content-Type", containing("xml"))
+            .willReturn(ok()
+                .withHeader("Content-Type", "text/xml")
+                .withBody("<response>SUCCESS</response>")));
 
-    // Send the request and receive the response
-    final HttpResponse<String> response =
-            client.send(request, HttpResponse.BodyHandlers.ofString());
+        // Setup HTTP POST request (with HTTP Client embedded in Java 11+)
+        final HttpClient client = HttpClient.newBuilder().build();
+        final HttpRequest request = HttpRequest.newBuilder()
+            .uri(URI.create(wmRuntimeInfo.getHttpBaseUrl() + "/my/resource"))
+            .header("Content-Type", "text/xml")
+            .POST(HttpRequest.BodyPublishers.noBody())
+            .build();
 
-    // Verify the response (with AssertJ)
-    assertThat(response.statusCode()).as("Wrong response status code").isEqualTo(200);
-    assertThat(response.body()).as("Wrong response body").contains("<response>SUCCESS</response>");
+        // Send the request and receive the response
+        final HttpResponse<String> response =
+                client.send(request, HttpResponse.BodyHandlers.ofString());
+
+        // Verify the response (with AssertJ)
+        assertThat(response.statusCode()).as("Wrong response status code").isEqualTo(200);
+        assertThat(response.body()).as("Wrong response body").contains("<response>SUCCESS</response>");
+    }
 }
 ```
 
 ## Extend the test
 
 For a bit more control over the settings of the WireMock server created
-by the rule you can pass a fluently built Options object to either rule's constructor.
-Let's change the port numbers as an example.
+by the extension you can configure the annotation or switch to the
+programmatic Jupiter extension API. Let's change the port numbers as an example.
 
 ### Change the port numbers
 
 ```java
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-...
-
-@Rule
-public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().port(8089).httpsPort(8443));
+@WireMockTest(httpPort = 8089, httpsEnabled = true, httpsPort = 8443)
+class ExampleTest {
+}
 ```
 
 ### Random port numbers
 
-You can have WireMock (or more accurately the JVM) pick random, free
+By default, WireMock will pick random, free
 HTTP and HTTPS ports.
 It is a great idea if you want to run your tests concurrently.
 
 ```java
-@Rule
-public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+@WireMockTest(httpsEnabled = true)
+class ExampleTest {
+}
 ```
 
 Then find out which ports to use from your tests as follows:
 
 ```java
-int port = wireMockRule.port();
-int httpsPort = wireMockRule.httpsPort();
+@Test
+void exampleTest(WireMockRuntimeInfo wmRuntimeInfo) {
+    int port = wmRuntimeInfo.getHttpPort();
+    int httpsPort = wmRuntimeInfo.getHttpsPort();
+}
 ```
 
 ## Further reading
 
 - For more details on verifying requests and stubbing responses, see [Stubbing](../../stubbing/) and [Verifying](../../verifying/)
-- For more information on the JUnit 4 rules see [The JUnit 4 Rule](../../junit-extensions/).
-- For more information on the JUnit 5 Jupiter extension see [JUnit 5+ Jupiter](../../junit-jupiter/); for previous JUnit versions you can use [the JUnit 4 Rule](../../junit-extensions/).
+- For more information on the JUnit 5 Jupiter extension see [JUnit 5+ Jupiter](../../junit-jupiter/).
+- For previous JUnit versions you can use [the JUnit 4 Rule](../../junit-extensions/).
 - For many more examples of JUnit tests check out the
 [WireMock's own acceptance tests](https://github.com/wiremock/wiremock/tree/master/src/test/java/com/github/tomakehurst/wiremock)


### PR DESCRIPTION
Closes #257.

## Summary
- switch the Java quickstart page from JUnit 4 rule usage to JUnit 5 Jupiter extension usage
- update the sidebar and getting-started labels so they match the new quickstart content
- make the examples use @WireMockTest and WireMockRuntimeInfo for fixed and random port cases

## Verification
- pnpm.cmd install
- pnpm.cmd build (Astro rendered dist/docs/quickstart/java-junit/index.html and related docs successfully; the command still exits non-zero on Windows because of the repo's pre-existing copy-static-homepage hook trying to copy to C:\C:\...\dist\index.html)