### PR TITLE
Clarify JUnit Jupiter global templating setup

### DIFF
--- a/src/content/docs/docs/junit-jupiter.mdx
+++ b/src/content/docs/docs/junit-jupiter.mdx
@@ -106,13 +106,8 @@ public class ProgrammaticWireMockTest {
     static WireMockExtension wm2 = WireMockExtension.newInstance()
             .options(wireMockConfig()
                      .dynamicPort()
-                     .extensions(new ResponseTemplateTransformer(
-                          getTemplateEngine(),
-                          options.getResponseTemplatingGlobal(),
-                          getFiles(),
-                          templateModelProviders
-                        )
-                     )
+                     .templatingEnabled(true)
+                     .globalTemplating(true))
             .build();
 
     @Test
@@ -131,6 +126,9 @@ public class ProgrammaticWireMockTest {
     }
 }
 ```
+
+Use `templatingEnabled(true).globalTemplating(true)` to apply response templating to all stub responses in WireMock 3.x.
+Register custom extensions separately when you need extra template helpers or model data providers, not to enable global templating itself.
 
 ### Static vs. instance
 


### PR DESCRIPTION
Fixes #164.

## Summary
- replace the stale `ResponseTemplateTransformer(...)` example in the JUnit Jupiter docs with the current WireMock 3.x configuration API
- explain that `templatingEnabled(true).globalTemplating(true)` enables global response templating, while custom extensions should be registered separately

## Verification
- `pnpm.cmd install`
- `pnpm.cmd build` renders `dist/docs/junit-jupiter/index.html` with the updated snippet, but still exits non-zero because of the repo's pre-existing Windows `copy-static-homepage` hook bug (`C:\C:\...\dist\index.html` copy target)